### PR TITLE
Missing setting of CURLINFO_HEADER_OUT option

### DIFF
--- a/src/Client/Adapter/Curl.php
+++ b/src/Client/Adapter/Curl.php
@@ -348,6 +348,9 @@ class Curl implements HttpAdapter, StreamInterface
         curl_setopt($this->curl, CURLOPT_HTTP_VERSION, $curlHttp);
         curl_setopt($this->curl, $curlMethod, $curlValue);
 
+        // Set the CURLINFO_HEADER_OUT flag so that we can retrieve the full request string later
+        curl_setopt($this->curl, CURLINFO_HEADER_OUT, true);
+
         if ($this->outputStream) {
             // headers will be read into the response
             curl_setopt($this->curl, CURLOPT_HEADER, false);


### PR DESCRIPTION
The CURLINFO_HEADER_OUT option is not set in the curl adapter which results in Client::getLastRawRequest to be empty