### PR TITLE
Fix invalid exception from urlencoded cookie value

### DIFF
--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -302,7 +302,6 @@ class SetCookie implements MultipleHeaderInterface
      */
     public function setValue($value)
     {
-        HeaderValue::assertValid($value);
         $this->value = $value;
         return $this;
     }

--- a/test/Header/SetCookieTest.php
+++ b/test/Header/SetCookieTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Http\Header;
 
+use Zend\Http\Header\HeaderValue;
 use Zend\Http\Header\SetCookie;
 
 class SetCookieTest extends \PHPUnit_Framework_TestCase
@@ -431,8 +432,8 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
      */
     public function testPreventsCRLFAttackViaConstructor()
     {
-        $this->setExpectedException('Zend\Http\Header\Exception\InvalidArgumentException');
         $header = new SetCookie("leo_auth_token", "example\r\n\r\nevilContent");
+        $this->assertTrue(HeaderValue::isValid($header->getFieldValue()));
     }
 
     public function setterInjections()

--- a/test/Header/SetCookieTest.php
+++ b/test/Header/SetCookieTest.php
@@ -435,6 +435,13 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Set-Cookie: leo_auth_token=example%0D%0A%0D%0AevilContent', $header->toString());
     }
 
+    public function testPreventsCRLFAttackViaSetValue()
+    {
+        $header = new SetCookie("leo_auth_token");
+        $header->setValue("example\r\n\r\nevilContent");
+        $this->assertEquals('Set-Cookie: leo_auth_token=example%0D%0A%0D%0AevilContent', $header->toString());
+    }
+
     public function setterInjections()
     {
         return [

--- a/test/Header/SetCookieTest.php
+++ b/test/Header/SetCookieTest.php
@@ -9,7 +9,6 @@
 
 namespace ZendTest\Http\Header;
 
-use Zend\Http\Header\HeaderValue;
 use Zend\Http\Header\SetCookie;
 
 class SetCookieTest extends \PHPUnit_Framework_TestCase
@@ -433,7 +432,7 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
     public function testPreventsCRLFAttackViaConstructor()
     {
         $header = new SetCookie("leo_auth_token", "example\r\n\r\nevilContent");
-        $this->assertTrue(HeaderValue::isValid($header->getFieldValue()));
+        $this->assertEquals('Set-Cookie: leo_auth_token=example%0D%0A%0D%0AevilContent', $header->toString());
     }
 
     public function setterInjections()


### PR DESCRIPTION
This is my alternative solution to #15, as a replacement for the existing PR #16.

This PR fixes the problem by simply re-urlencoding the cookie value before validating it. This is allowable because the actual cookie as output *also* urlencodes the value (see [SetCookie::getFieldValue](https://github.com/zerocrates/zend-http/blob/master/src/Header/SetCookie.php#L236).

As a concrete example, this PR removes the test `testPreventsCRLFAttackViaConstructor`. The change makes that test fail, but the test was already failing for an input that wouldn't have actually enabled a CRLF attack. The "evil" example is:

```php
$header = new SetCookie("leo_auth_token", "example\r\n\r\nevilContent");
```

However, under both the existing code and after the commit in this PR, that SetCookie header creates no CRLF injection problems, because SetCookie already automatically urlencodes values on output. So, the output of `$header->toString()` on the above "evil" cookie is already safe:

```
Set-Cookie: leo_auth_token=example%0D%0A%0D%0AevilContent
```

I think this change is the best way to fix the regression without compromising the security the validation was introduced to provide and without surprising users by changing the header's behavior.

Fix #15
Supersede & close #16