### PR TITLE
Using http_build_query for application/x-www-form-urlencoded

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1228,7 +1228,7 @@ class Client implements Stdlib\DispatchableInterface
                 $body .= "--{$boundary}--\r\n";
             } elseif (stripos($this->getEncType(), self::ENC_URLENCODED) === 0) {
                 // Encode body as application/x-www-form-urlencoded
-                $body = http_build_query($this->getRequest()->getPost()->toArray());
+                $body = http_build_query($this->getRequest()->getPost()->toArray(), null, '&');
             } else {
                 throw new Client\Exception\RuntimeException("Cannot handle content type '{$this->encType}' automatically");
             }


### PR DESCRIPTION
By standard "&" character is used for application/x-www-form-urlencoded submissions. If  separator is set to different value via ini_set('arg_separator.output', 'some other'); it will break http client with wrong request.

I suggest to hardcode "&" there
