### PR TITLE
Updates dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#42](https://github.com/zendframework/zend-http/pull/42) updates dependencies
+  to ensure it can work with PHP 5.5+ and 7.0+, as well as zend-stdlib
+  2.5+/3.0+.
 
 ## 2.5.3 - 2015-09-14
 

--- a/composer.json
+++ b/composer.json
@@ -7,34 +7,32 @@
         "http"
     ],
     "homepage": "https://github.com/zendframework/zend-http",
-    "autoload": {
-        "psr-4": {
-            "Zend\\Http\\": "src/"
-        }
-    },
-    "require": {
-        "php": ">=5.5",
-        "zendframework/zend-loader": "~2.5",
-        "zendframework/zend-stdlib": "~2.5",
-        "zendframework/zend-uri": "~2.5",
-        "zendframework/zend-validator": "~2.5"
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "extra": {
         "branch-alias": {
             "dev-master": "2.5-dev",
             "dev-develop": "2.6-dev"
         }
     },
+    "require": {
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-loader": "^2.5",
+        "zendframework/zend-stdlib": "^2.5 || ^3.0",
+        "zendframework/zend-uri": "^2.5",
+        "zendframework/zend-validator": "^2.5"
+    },
+    "require-dev": {
+        "fabpot/php-cs-fixer": "1.7.*",
+        "phpunit/PHPUnit": "^4.0",
+        "zendframework/zend-config": "^2.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Zend\\Http\\": "src/"
+        }
+    },
     "autoload-dev": {
         "psr-4": {
             "ZendTest\\Http\\": "test/"
         }
-    },
-    "require-dev": {
-        "fabpot/php-cs-fixer": "1.7.*",
-        "phpunit/PHPUnit": "~4.0",
-        "zendframework/zend-config": "~2.5"
     }
 }


### PR DESCRIPTION
- PHP: `^5.5 || ^7.0`.
- zend-stdlib: `^2.5 || ^3.0`.
- Use the `^` constraint in place of `~` whenever possible.

This is primarily to allow picking up the latest 2.X versions of components, as they release updates to work with v2 + v3 of servicemanager, eventmanager, and stdlib.