### PR TITLE
All headers are case insensitive and should be treated as such to pre…

### DIFF
--- a/src/Client/Adapter/Curl.php
+++ b/src/Client/Adapter/Curl.php
@@ -434,13 +434,13 @@ class Curl implements HttpAdapter, StreamInterface
 
         // cURL automatically decodes chunked-messages, this means we have to
         // disallow the Zend\Http\Response to do it again.
-        $responseHeaders = preg_replace("/Transfer-Encoding:\s*chunked\\r\\n/", "", $responseHeaders);
+        $responseHeaders = preg_replace("/Transfer-Encoding:\s*chunked\\r\\n/i", "", $responseHeaders);
 
         // cURL can automatically handle content encoding; prevent double-decoding from occurring
         if (isset($this->config['curloptions'][CURLOPT_ENCODING])
             && '' == $this->config['curloptions'][CURLOPT_ENCODING]
         ) {
-            $responseHeaders = preg_replace("/Content-Encoding:\s*gzip\\r\\n/", '', $responseHeaders);
+            $responseHeaders = preg_replace("/Content-Encoding:\s*gzip\\r\\n/i", '', $responseHeaders);
         }
 
         // cURL automatically handles Proxy rewrites, remove the "HTTP/1.0 200 Connection established" string:

--- a/test/Client/CurlTest.php
+++ b/test/Client/CurlTest.php
@@ -397,4 +397,29 @@ class CurlTest extends CommonHttpTests
         $this->client->send();
         $this->assertEquals('foo=bar', $this->client->getResponse()->getBody());
     }
+
+    /**
+     * @group ZF-7683
+     * @see https://github.com/zendframework/zend-http/pull/53
+     *
+     * Note: The headers stored in ZF7683-chunked.php are case insensitive
+     */
+     public function testNoCaseSensitiveHeaderName()
+     {
+        $this->client->setUri($this->baseuri . 'ZF7683-chunked.php');
+
+        $adapter = new Adapter\Curl();
+        $adapter->setOptions([
+          'curloptions' => [
+            CURLOPT_ENCODING => '',
+          ],
+        ]);
+        $this->client->setAdapter($adapter);
+        $this->client->setMethod('GET');
+        $this->client->send();
+
+        $headers = $this->client->getResponse()->getHeaders();
+        $this->assertFalse($headers->has('Transfer-Encoding'));
+        $this->assertFalse($headers->has('Content-Encoding'));
+    }
 }

--- a/test/Client/_files/ZF7683-chunked.php
+++ b/test/Client/_files/ZF7683-chunked.php
@@ -1,0 +1,4 @@
+<?php
+// intentional use of case-insensitive header name
+header("Transfer-encoding: chunked");
+header("content-encoding: gzip");


### PR DESCRIPTION
…vent errors. See: https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html

Fixes https://github.com/zendframework/zf2/issues/7683