### PR TITLE
Avoid triggering a notice with special crafted accept headers

### DIFF
--- a/src/Header/AbstractAccept.php
+++ b/src/Header/AbstractAccept.php
@@ -170,7 +170,12 @@ abstract class AbstractAccept implements HeaderInterface
             foreach ($paramsStrings as $param) {
                 $explode = explode('=', $param, 2);
 
-                $value = trim($explode[1]);
+                if (count($explode) === 2) {
+                    $value = trim($explode[1]);
+                } else {
+                    $value = null;
+                }
+
                 if (isset($value[0]) && $value[0] == '"' && substr($value, -1) == '"') {
                     $value = substr(substr($value, 1), 0, -1);
                 }
@@ -226,9 +231,9 @@ abstract class AbstractAccept implements HeaderInterface
         );
 
         if ($escaped == $value && !array_intersect(str_split($value), $separators)) {
-            $value = $key . '=' . $value;
+            $value = $key . ($value ? '=' . $value : '');
         } else {
-            $value = $key . '="' . $escaped . '"';
+            $value = $key . ($value ? '="' . $escaped . '"' : '');
         }
 
         return $value;

--- a/test/Header/AcceptCharsetTest.php
+++ b/test/Header/AcceptCharsetTest.php
@@ -32,6 +32,12 @@ class AcceptCharsetTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('xxx', $acceptCharsetHeader->getFieldValue());
     }
 
+    public function testAcceptCharsetGetFieldValueReturnsProperValueWithTrailingSemicolon()
+    {
+        $acceptCharsetHeader = AcceptCharset::fromString('Accept-Charset: xxx;');
+        $this->assertEquals('xxx', $acceptCharsetHeader->getFieldValue());
+    }
+
     public function testAcceptCharsetGetFieldValueReturnsProperValueWithSemicolonWithoutEqualSign()
     {
         $acceptCharsetHeader = AcceptCharset::fromString('Accept-Charset: xxx;yyy');

--- a/test/Header/AcceptCharsetTest.php
+++ b/test/Header/AcceptCharsetTest.php
@@ -32,6 +32,12 @@ class AcceptCharsetTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('xxx', $acceptCharsetHeader->getFieldValue());
     }
 
+    public function testAcceptCharsetGetFieldValueReturnsProperValueWithSemicolonWithoutEqualSign()
+    {
+        $acceptCharsetHeader = AcceptCharset::fromString('Accept-Charset: xxx;yyy');
+        $this->assertEquals('xxx;yyy', $acceptCharsetHeader->getFieldValue());
+    }
+
     public function testAcceptCharsetToStringReturnsHeaderFormattedString()
     {
         $acceptCharsetHeader = new AcceptCharset();

--- a/test/Header/AcceptEncodingTest.php
+++ b/test/Header/AcceptEncodingTest.php
@@ -32,6 +32,18 @@ class AcceptEncodingTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('xxx', $acceptEncodingHeader->getFieldValue());
     }
 
+    public function testAcceptEncodingGetFieldValueReturnsProperValueWithTrailingSemicolon()
+    {
+        $acceptEncodingHeader = AcceptEncoding::fromString('Accept-Encoding: xxx;');
+        $this->assertEquals('xxx', $acceptEncodingHeader->getFieldValue());
+    }
+
+    public function testAcceptEncodingGetFieldValueReturnsProperValueWithSemicolonWithoutEqualSign()
+    {
+        $acceptEncodingHeader = AcceptEncoding::fromString('Accept-Encoding: xxx;yyy');
+        $this->assertEquals('xxx;yyy', $acceptEncodingHeader->getFieldValue());
+    }
+
     public function testAcceptEncodingToStringReturnsHeaderFormattedString()
     {
         $acceptEncodingHeader = new AcceptEncoding();

--- a/test/Header/AcceptLanguageTest.php
+++ b/test/Header/AcceptLanguageTest.php
@@ -32,6 +32,18 @@ class AcceptLanguageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('xxx', $acceptLanguageHeader->getFieldValue());
     }
 
+    public function testAcceptLanguageGetFieldValueReturnsProperValueWithTrailingSemicolon()
+    {
+        $acceptLanguageHeader = AcceptLanguage::fromString('Accept-Language: xxx;');
+        $this->assertEquals('xxx', $acceptLanguageHeader->getFieldValue());
+    }
+
+    public function testAcceptLanguageGetFieldValueReturnsProperValueWithSemicolonWithoutEqualSign()
+    {
+        $acceptLanguageHeader = AcceptLanguage::fromString('Accept-Language: xxx;yyy');
+        $this->assertEquals('xxx;yyy', $acceptLanguageHeader->getFieldValue());
+    }
+
     public function testAcceptLanguageToStringReturnsHeaderFormattedString()
     {
         $acceptLanguageHeader = new AcceptLanguage();


### PR DESCRIPTION
Avoid triggering a notice when an accept header without an equal sign is parsed.

Refs #57