### PR TITLE
fixed Content-Length header

### DIFF
--- a/src/Header/ContentLength.php
+++ b/src/Header/ContentLength.php
@@ -38,12 +38,21 @@ class ContentLength implements HeaderInterface
         return $header;
     }
 
-    public function __construct($value = null)
+    public function __construct($value)
     {
-        if ($value) {
-            HeaderValue::assertValid($value);
-            $this->value = $value;
+        $this->setFieldValue($value);
+    }
+
+    public function setFieldValue($value)
+    {
+        $value = (string) $value;
+        if (!HeaderValue::isValid($value) || !preg_match('/^(0|[1-9][0-9]*)$/', $value)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Invalid header value for Content-Length: "%s"',
+                $value
+            ));
         }
+        $this->value = $value;
     }
 
     public function getFieldName()


### PR DESCRIPTION
* It's no more possible to have a Content-Length header with `NULL` as value
* allow `Content-Length: 0`, fixes #26
* added `ContentLength::setFieldValue()`
* throw exception on invalid `Content-Type` headers like `Content-Type: 123.456`
* restructured unit tests