### PR TITLE
Fixed the zero value in ContentLength

### DIFF
--- a/src/Header/ContentLength.php
+++ b/src/Header/ContentLength.php
@@ -40,7 +40,7 @@ class ContentLength implements HeaderInterface
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if (null !== $value) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }

--- a/test/Header/ContentLengthTest.php
+++ b/test/Header/ContentLengthTest.php
@@ -65,4 +65,11 @@ class ContentLengthTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Http\Header\Exception\InvalidArgumentException');
         $header = new ContentLength("Content-Length: xxx\r\n\r\nevilContent");
     }
+
+    public function testZeroValue()
+    {
+        $contentLengthHeader = new ContentLength(0);
+        $this->assertEquals(0, $contentLengthHeader->getFieldValue());
+        $this->assertEquals('Content-Length: 0', $contentLengthHeader->toString());
+    }
 }


### PR DESCRIPTION
This PR fixes zendframework/zend-http#26 allowing zero value (0) to `Header/ContentLength`