### PR TITLE
Fix CSP report-uri directive defaulting to 'none' when empty value provided

### DIFF
--- a/src/Header/ContentSecurityPolicy.php
+++ b/src/Header/ContentSecurityPolicy.php
@@ -73,6 +73,12 @@ class ContentSecurityPolicy implements HeaderInterface
             ));
         }
         if (empty($sources)) {
+            if ('report-uri' === $name) {
+                if (isset($this->directives[$name])) {
+                    unset($this->directives[$name]);
+                }
+                return $this;
+            }
             $this->directives[$name] = "'none'";
             return $this;
         }

--- a/test/Header/ContentSecurityPolicyTest.php
+++ b/test/Header/ContentSecurityPolicyTest.php
@@ -110,4 +110,30 @@ class ContentSecurityPolicyTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Http\Header\Exception\InvalidArgumentException');
         $header->setDirective('default-src', ["\rsome\r\nCRLF\ninjection"]);
     }
+
+    public function testContentSecurityPolicySetDirectiveWithEmptyReportUriDefaultsToUnset()
+    {
+        $csp = new ContentSecurityPolicy();
+        $csp->setDirective('report-uri', []);
+        $this->assertEquals(
+            "Content-Security-Policy: ",
+            $csp->toString()
+        );
+    }
+
+    public function testContentSecurityPolicySetDirectiveWithEmptyReportUriRemovesExistingValue()
+    {
+        $csp = new ContentSecurityPolicy();
+        $csp->setDirective('report-uri', ['csp-error']);
+        $this->assertEquals(
+            "Content-Security-Policy: report-uri csp-error;",
+            $csp->toString()
+        );
+
+        $csp->setDirective('report-uri', []);
+        $this->assertEquals(
+            "Content-Security-Policy: ",
+            $csp->toString()
+        );
+    }
 }


### PR DESCRIPTION
If `setDirective` is called on `\Zend\Http\Header\ContentSecurityPolicy` with an empty array for report-uri the resulting header contains `report-uri: 'none'`

`$csp->setDirective('report-uri', []);`

According to CSP2 specification https://www.w3.org/TR/CSP2/ the report-uri directive is not a source-list, it actually accepts 1 or more uri-reference. This means the default of 'none' is not treated as no report-uri.

If report-uri is defaulted to 'none', I have observed CSP errors being reported to an endpoint of `host/'none'`

Screenshot of Network tab in both Chrome and Firefox with report-uri:'none':
![csp-report-uri-none](https://cloud.githubusercontent.com/assets/1941262/19831417/3c52939c-9e01-11e6-8c3c-83d2f784321c.png)

My proposed fix will ensure that the report-uri directive is unset if an empty array is provided rather than defaulting to 'none'. This will then omit the report-uri from the ContentSecurityPolicy header which achieves what I would expect for an empty report-uri

I have created branches of ZendSkeletonApplication.
One which highlights the error
https://github.com/tkjn/ZendSkeletonApplication/tree/csp-report-uri-none-error
And another which uses my proposed fix
https://github.com/tkjn/ZendSkeletonApplication/tree/csp-report-uri-none-error-fixed
