### PR TITLE
Add support to sslcafile and sslcapath to cURL adapter

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -110,7 +110,9 @@ class Client implements Stdlib\DispatchableInterface
         'outputstream'    => false,
         'encodecookies'   => true,
         'argseparator'    => null,
-        'rfc3986strict'   => false
+        'rfc3986strict'   => false,
+        'sslcafile'       => null,
+        'sslcapath'       => null,
     ];
 
     /**

--- a/src/Client/Adapter/Curl.php
+++ b/src/Client/Adapter/Curl.php
@@ -209,6 +209,13 @@ class Curl implements HttpAdapter, StreamInterface
             }
         }
 
+        if (isset($this->config['sslcafile']) && $this->config['sslcafile']) {
+            curl_setopt($this->curl, CURLOPT_CAINFO, $this->config['sslcafile']);
+        }
+        if (isset($this->config['sslcapath']) && $this->config['sslcapath']) {
+            curl_setopt($this->curl, CURLOPT_CAPATH, $this->config['sslcapath']);
+        }
+
         if (isset($this->config['maxredirects'])) {
             // Set Max redirects
             curl_setopt($this->curl, CURLOPT_MAXREDIRS, $this->config['maxredirects']);


### PR DESCRIPTION
Socket adapter supports the options `sslcafile` and `sslcapath`.

What about supporting them in the cURL Adapter too?