### PR TITLE
Normalize timeout exception

### DIFF
--- a/src/Client/Adapter/Curl.php
+++ b/src/Client/Adapter/Curl.php
@@ -21,6 +21,13 @@ use Zend\Stdlib\ArrayUtils;
 class Curl implements HttpAdapter, StreamInterface
 {
     /**
+     * Operation timeout.
+     *
+     * @var int
+     */
+    const ERROR_OPERATION_TIMEDOUT = 28;
+
+    /**
      * Parameters array
      *
      * @var array
@@ -247,6 +254,7 @@ class Curl implements HttpAdapter, StreamInterface
      *     to wrong host, no PUT file defined, unsupported method, or unsupported
      *     cURL option.
      * @throws AdapterException\InvalidArgumentException if $method is currently not supported
+     * @throws AdapterException\TimeoutException if connection timed out
      */
     public function write($method, $uri, $httpVersion = 1.1, $headers = [], $body = '')
     {
@@ -425,6 +433,12 @@ class Curl implements HttpAdapter, StreamInterface
         $request .= $body;
 
         if (empty($this->response)) {
+            if (curl_errno($this->curl) === static::ERROR_OPERATION_TIMEDOUT) {
+                throw new AdapterException\TimeoutException(
+                    "Read timed out",
+                    AdapterException\TimeoutException::READ_TIMEOUT
+                );
+            }
             throw new AdapterException\RuntimeException("Error in cURL request: " . curl_error($this->curl));
         }
 

--- a/test/Client/CurlTest.php
+++ b/test/Client/CurlTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Http\Client;
 
 use Zend\Config\Config;
 use Zend\Http\Client\Adapter;
+use Zend\Http\Client\Adapter\Exception\TimeoutException;
 
 /**
  * This Testsuite includes all Zend_Http_Client that require a working web
@@ -423,5 +424,24 @@ class CurlTest extends CommonHttpTests
 
         $this->assertFalse($headers->has('Transfer-Encoding'));
         $this->assertFalse($headers->has('Content-Encoding'));
+    }
+
+    public function testTimeout()
+    {
+        $this->client
+            ->setUri($this->baseuri . 'testTimeout.php')
+            ->setOptions([
+                'timeout' => 1,
+            ]);
+        $adapter = new Adapter\Curl();
+        $this->client->setAdapter($adapter);
+        $this->client->setMethod('GET');
+        $timeoutException = null;
+        try {
+            $this->client->send();
+        } catch (TimeoutException $x) {
+            $timeoutException = $x;
+        }
+        $this->assertNotNull($timeoutException);
     }
 }

--- a/test/Client/_files/testTimeout.php
+++ b/test/Client/_files/testTimeout.php
@@ -1,0 +1,5 @@
+<?php
+
+sleep(2);
+
+echo 'done.';


### PR DESCRIPTION
When the Socket adapter meet timeout problems, it raises an `AdapterException\TimeoutException` exception.

Let's do the same for the cURL client too.