### PR TITLE
Allow the usage of "Expires: 0" header

### DIFF
--- a/src/Header/Expires.php
+++ b/src/Header/Expires.php
@@ -32,7 +32,7 @@ class Expires extends AbstractDate
 
     public function setDate($date)
     {
-        if ($date === '0') {
+        if ($date === '0' || $date === 0) {
             $date = date(DATE_W3C, 0); // Thu, 01 Jan 1970 00:00:00 GMT
         }
         return parent::setDate($date);

--- a/src/Header/Expires.php
+++ b/src/Header/Expires.php
@@ -9,6 +9,9 @@
 
 namespace Zend\Http\Header;
 
+use DateTime;
+use DateTimeZone;
+
 /**
  * Expires Header
  *
@@ -24,5 +27,14 @@ class Expires extends AbstractDate
     public function getFieldName()
     {
         return 'Expires';
+    }
+
+
+    public function setDate($date)
+    {
+        if ($date === '0') {
+            $date = date(DATE_W3C, 0); // Thu, 01 Jan 1970 00:00:00 GMT
+        }
+        return parent::setDate($date);
     }
 }

--- a/test/Header/ExpiresTest.php
+++ b/test/Header/ExpiresTest.php
@@ -63,5 +63,9 @@ class ExpiresTest extends \PHPUnit_Framework_TestCase
         $expires = new Expires();
         $expires->setDate('0');
         $this->assertEquals('Expires: Thu, 01 Jan 1970 00:00:00 GMT', $expires->toString());
+
+        $expires = new Expires();
+        $expires->setDate(0);
+        $this->assertEquals('Expires: Thu, 01 Jan 1970 00:00:00 GMT', $expires->toString());
     }
 }

--- a/test/Header/ExpiresTest.php
+++ b/test/Header/ExpiresTest.php
@@ -54,4 +54,14 @@ class ExpiresTest extends \PHPUnit_Framework_TestCase
     {
         $header = Expires::fromString("Expires: Sun, 06 Nov 1994 08:49:37 GMT\r\n\r\nevilContent");
     }
+
+    public function testExpiresSetToZero()
+    {
+        $expires = Expires::fromString("Expires: 0");
+        $this->assertEquals('Expires: Thu, 01 Jan 1970 00:00:00 GMT', $expires->toString());
+
+        $expires = new Expires();
+        $expires->setDate('0');
+        $this->assertEquals('Expires: Thu, 01 Jan 1970 00:00:00 GMT', $expires->toString());
+    }
 }


### PR DESCRIPTION
This PR fixes #103, allowing `Expires: 0` header. I used the timestamp 0 that is equivalent to "Thu, 01 Jan 1970 00:00:00 GMT".