### PR TITLE
Fixed the unit test for phpunit 4.8.33

### DIFF
--- a/test/Client/CommonHttpTests.php
+++ b/test/Client/CommonHttpTests.php
@@ -75,7 +75,7 @@ abstract class CommonHttpTests extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         if (getenv('TESTS_ZEND_HTTP_CLIENT_BASEURI')
-            && (getenv('TESTS_ZEND_HTTP_CLIENT_BASEURI') != false)) {
+            && (filter_var(getenv('TESTS_ZEND_HTTP_CLIENT_BASEURI'), FILTER_VALIDATE_BOOLEAN) != false)) {
             $this->baseuri = getenv('TESTS_ZEND_HTTP_CLIENT_BASEURI');
             if (substr($this->baseuri, -1) != '/') {
                 $this->baseuri .= '/';

--- a/test/Client/ProxyAdapterTest.php
+++ b/test/Client/ProxyAdapterTest.php
@@ -35,7 +35,7 @@ class ProxyAdapterTest extends SocketTest
     protected function setUp()
     {
         if (getenv('TESTS_ZEND_HTTP_CLIENT_HTTP_PROXY') &&
-              getenv('TESTS_ZEND_HTTP_CLIENT_HTTP_PROXY')) {
+              filter_var(getenv('TESTS_ZEND_HTTP_CLIENT_BASEURI'), FILTER_VALIDATE_BOOLEAN)) {
             list($host, $port) = explode(':', getenv('TESTS_ZEND_HTTP_CLIENT_HTTP_PROXY'), 2);
 
             if (! $host) {

--- a/test/Client/StaticClientTest.php
+++ b/test/Client/StaticClientTest.php
@@ -33,7 +33,7 @@ class StaticClientTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         if (getenv('TESTS_ZEND_HTTP_CLIENT_BASEURI')
-            && (getenv('TESTS_ZEND_HTTP_CLIENT_BASEURI') != false)) {
+            && (filter_var(getenv('TESTS_ZEND_HTTP_CLIENT_BASEURI'), FILTER_VALIDATE_BOOLEAN) != false)) {
             $this->baseuri = getenv('TESTS_ZEND_HTTP_CLIENT_BASEURI');
             if (substr($this->baseuri, -1) != '/') {
                 $this->baseuri .= '/';

--- a/test/Client/UseCaseTest.php
+++ b/test/Client/UseCaseTest.php
@@ -58,7 +58,7 @@ class UseCaseTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         if (getenv('TESTS_ZEND_HTTP_CLIENT_BASEURI')
-            && (getenv('TESTS_ZEND_HTTP_CLIENT_BASEURI') != false)
+            && (filter_var(getenv('TESTS_ZEND_HTTP_CLIENT_BASEURI'), FILTER_VALIDATE_BOOLEAN) != false)
         ) {
             $this->baseuri = getenv('TESTS_ZEND_HTTP_CLIENT_BASEURI');
             $this->client  = new HTTPClient($this->baseuri);


### PR DESCRIPTION
This PR fixes the issue with phpunit 4.8.33 that introduced a BC break [here](https://github.com/sebastianbergmann/phpunit/issues/2331). I also opened this [issue](https://github.com/sebastianbergmann/phpunit/issues/2447) on phpunit repository, asking for more information.