### PR TITLE
Add to Proxy adapter all the options of the Socket adapter

### DIFF
--- a/src/Client/Adapter/Proxy.php
+++ b/src/Client/Adapter/Proxy.php
@@ -31,19 +31,21 @@ class Proxy extends Socket
      * @var array
      */
     protected $config = [
+        'persistent'         => false,
         'ssltransport'       => 'ssl',
         'sslcert'            => null,
         'sslpassphrase'      => null,
         'sslverifypeer'      => true,
+        'sslcafile'          => null,
         'sslcapath'          => null,
         'sslallowselfsigned' => false,
         'sslusecontext'      => false,
+        'sslverifypeername'  => true,
         'proxy_host'         => '',
         'proxy_port'         => 8080,
         'proxy_user'         => '',
         'proxy_pass'         => '',
         'proxy_auth'         => Client::AUTH_BASIC,
-        'persistent'         => false
     ];
 
     /**

--- a/test/Client/ProxyAdapterTest.php
+++ b/test/Client/ProxyAdapterTest.php
@@ -132,4 +132,19 @@ class ProxyAdapterTest extends SocketTest
         $this->assertSame($this->host, $adapterHost);
         $this->assertSame($this->port, $adapterPort);
     }
+
+    public function testProxyHasAllSocketConfigs()
+    {
+        $socket = new \Zend\Http\Client\Adapter\Socket();
+        $socketConfig = $socket->getConfig();
+        $proxy = new \Zend\Http\Client\Adapter\Proxy();
+        $proxyConfig = $proxy->getConfig();
+        foreach (array_keys($socketConfig) as $socketConfigKey) {
+            $this->assertArrayHasKey(
+                $socketConfigKey,
+                $proxyConfig,
+                "Proxy adapter should have all the Socket configuration keys"
+            );
+        }
+    }
 }


### PR DESCRIPTION
`sslcafile` and `sslverifypeername` were present in the `Socket` adapter but not in the `Proxy` adapter.

We need all the options in order to avoid PHP warnings about accessing invalid array keys.