### PR TITLE
Very inefficient decoding of large chunked messages!

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -505,17 +505,25 @@ class Response extends AbstractMessage implements ResponseInterface
     {
         $decBody = '';
 
-        while (trim($body)) {
-            if (! preg_match("/^([\da-fA-F]+)[^\r\n]*\r\n/sm", $body, $m)) {
-                throw new Exception\RuntimeException(
-                    "Error parsing body - doesn't seem to be a chunked message"
-                );
+        $offset = 0;
+        
+        while (true) {
+            if (! preg_match("/^([\da-fA-F]+)[^\r\n]*\r\n/sm", $body, $m, 0, $offset)) {
+                if (!empty(trim(substr($body, $offset)))) {
+                    // Message was not consumed completely! 
+                    throw new Exception\RuntimeException(
+                            "Error parsing body - doesn't seem to be a chunked message"
+                    );
+                } else {
+                    // Message was consumed completely
+                    break; 
+                }
             }
 
             $length   = hexdec(trim($m[1]));
             $cut      = strlen($m[0]);
-            $decBody .= substr($body, $cut, $length);
-            $body     = substr($body, $cut + $length + 2);
+            $decBody .= substr($body, $offset+$cut, $length);
+            $offset += $cut + $length + 2;
         }
 
         return $decBody;

--- a/src/Response.php
+++ b/src/Response.php
@@ -506,23 +506,23 @@ class Response extends AbstractMessage implements ResponseInterface
         $decBody = '';
 
         $offset = 0;
-        
+
         while (true) {
             if (! preg_match("/^([\da-fA-F]+)[^\r\n]*\r\n/sm", $body, $m, 0, $offset)) {
-                if (!empty(trim(substr($body, $offset)))) {
-                    // Message was not consumed completely! 
+                if (! empty(trim(substr($body, $offset)))) {
+                    // Message was not consumed completely!
                     throw new Exception\RuntimeException(
-                            "Error parsing body - doesn't seem to be a chunked message"
+                        "Error parsing body - doesn't seem to be a chunked message"
                     );
                 } else {
                     // Message was consumed completely
-                    break; 
+                    break;
                 }
             }
 
             $length   = hexdec(trim($m[1]));
             $cut      = strlen($m[0]);
-            $decBody .= substr($body, $offset+$cut, $length);
+            $decBody .= substr($body, $offset + $cut, $length);
             $offset += $cut + $length + 2;
         }
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -509,15 +509,14 @@ class Response extends AbstractMessage implements ResponseInterface
 
         while (true) {
             if (! preg_match("/^([\da-fA-F]+)[^\r\n]*\r\n/sm", $body, $m, 0, $offset)) {
-                if (! empty(trim(substr($body, $offset)))) {
+                if (trim(substr($body, $offset))) {
                     // Message was not consumed completely!
                     throw new Exception\RuntimeException(
-                        "Error parsing body - doesn't seem to be a chunked message"
+                        'Error parsing body - doesn\'t seem to be a chunked message'
                     );
-                } else {
-                    // Message was consumed completely
-                    break;
                 }
+                // Message was consumed completely
+                break;
             }
 
             $length   = hexdec(trim($m[1]));

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -211,7 +211,7 @@ class ResponseTest extends TestCase
         $response->setHeaders(Headers::fromString($headers));
 
         // avoid flakiness, repeat test
-        $timings = array(); 
+        $timings = [];
         for ($i = 0; $i < 4; $i++) {
             // get baseline for timing: 2000 x 1 Byte chunks
             $responseData = str_repeat($this->makeChunk(1), 2000);
@@ -223,9 +223,10 @@ class ResponseTest extends TestCase
             $response->setContent($responseData2);
             $time2 = $this->getTimeForGetBody($response);
 
-            // do not count the first iteration
-            if ($i) $timings[] = floor($time2 / $time1);
+            $timings[] = floor($time2 / $time1);
         }
+
+        array_shift($timings); // do not measure first iteration
 
         // make sure that the worst case packet will have an equal timing as the baseline
         $errMsg = 'Chunked response is not parsing large packets efficiently! Timings:';

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-http for the canonical source repository
- * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-http/blob/master/LICENSE.md New BSD License
  */
 
@@ -13,7 +13,6 @@ use Zend\Http\Exception\RuntimeException;
 use Zend\Http\Header\GenericHeader;
 use Zend\Http\Headers;
 use Zend\Http\Response;
-use Zend\Http\Headers;
 
 class ResponseTest extends TestCase
 {
@@ -181,24 +180,24 @@ class ResponseTest extends TestCase
     }
 
     /**
-     * @param number $chunksize the data size of the chunk to create
+     * @param int $chunksize the data size of the chunk to create
      * @return string a chunk of data for embedding inside a chunked response
      */
     private function makeChunk($chunksize)
     {
-        $chunkdata = str_repeat("W", $chunksize);
-        return "$chunksize\r\n$chunkdata\r\n";
+        $chunkdata = str_repeat('W', $chunksize);
+        return sprintf("%d\r\n%s\r\n", $chunksize, $chunkdata);
     }
 
     /**
      * @param Response $response
-     * @return the time that calling the getBody function took on the response
+     * @return float the time that calling the getBody function took on the response
      */
     private function getTimeForGetBody(Response $response)
     {
-        $time_start = microtime(true);
+        $timeStart = microtime(true);
         $response->getBody();
-        return microtime(true) - $time_start;
+        return microtime(true) - $timeStart;
     }
 
     /**
@@ -211,21 +210,20 @@ class ResponseTest extends TestCase
         $headers = file_get_contents(__DIR__ . '/_files/response_chunked_head');
         $response->setHeaders(Headers::fromString($headers));
 
-        // *** craft a special 'worst case' response, where 1000 1 Byte chunks are followed by a 1 MB Chunk ***
 
-        // Get baseline for timing: 1000 x 1 Byte chunks
+        // get baseline for timing: 1000 x 1 Byte chunks
         $responseData = str_repeat($this->makeChunk(1), 1000);
         $response->setContent($responseData);
         $time1 = $this->getTimeForGetBody($response);
 
-        // Get baseline for timing: 1000 x 1 Byte chunks
+        // 'worst case' response, where 1000 1 Byte chunks are followed by a 1 MB Chunk
         $responseData2 = $responseData . $this->makeChunk(1000000);
         $response->setContent($responseData2);
         $time2 = $this->getTimeForGetBody($response);
 
-        // Make sure that the worst case packet will have an equal timing as the baseline
-        $errMsg = "Chunked response is not parsing large packets efficiently: " . ($time2 / $time1);
-        $this->assertTrue(2 > ($time2 / $time1), $errMsg);
+        // make sure that the worst case packet will have an equal timing as the baseline
+        $errMsg = 'Chunked response is not parsing large packets efficiently!';
+        $this->assertLessThan(2, floor($time2 / $time1), $errMsg);
     }
 
     public function testLineBreaksCompatibility()

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -212,18 +212,18 @@ class ResponseTest extends TestCase
 
 
         // get baseline for timing: 1000 x 1 Byte chunks
-        $responseData = str_repeat($this->makeChunk(1), 1000);
+        $responseData = str_repeat($this->makeChunk(1), 2000);
         $response->setContent($responseData);
         $time1 = $this->getTimeForGetBody($response);
 
         // 'worst case' response, where 1000 1 Byte chunks are followed by a 1 MB Chunk
-        $responseData2 = $responseData . $this->makeChunk(1000000);
+        $responseData2 = $responseData . $this->makeChunk(10000000);
         $response->setContent($responseData2);
         $time2 = $this->getTimeForGetBody($response);
 
         // make sure that the worst case packet will have an equal timing as the baseline
         $errMsg = 'Chunked response is not parsing large packets efficiently!';
-        $this->assertLessThan(2, floor($time2 / $time1), $errMsg);
+        $this->assertLessThan(20, floor($time2 / $time1), $errMsg);
     }
 
     public function testLineBreaksCompatibility()

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -184,7 +184,8 @@ class ResponseTest extends TestCase
      * @param number $chunksize the data size of the chunk to create
      * @return string a chunk of data for embedding inside a chunked response
      */
-    private function makeChunk ($chunksize) {
+    private function makeChunk($chunksize)
+    {
         $chunkdata = str_repeat("W", $chunksize);
         return "$chunksize\r\n$chunkdata\r\n";
     }
@@ -193,7 +194,8 @@ class ResponseTest extends TestCase
      * @param Response $response
      * @return the time that calling the getBody function took on the response
      */
-    private function getTimeForGetBody (Response $response) {
+    private function getTimeForGetBody(Response $response)
+    {
         $time_start = microtime(true);
         $response->getBody();
         return microtime(true) - $time_start;
@@ -202,7 +204,8 @@ class ResponseTest extends TestCase
     /**
      * @small
      */
-    public function testChunkedResponsePerformance () {
+    public function testChunkedResponsePerformance()
+    {
         $response = new Response();
 
         $headers = file_get_contents(__DIR__ . '/_files/response_chunked_head');
@@ -221,7 +224,8 @@ class ResponseTest extends TestCase
         $time2 = $this->getTimeForGetBody($response);
 
         // Make sure that the worst case packet will have an equal timing as the baseline
-        $this->assertTrue(2 > ($time2 / $time1), "Chunked response is not parsing large packets efficiently: " . ($time2 / $time1));
+        $errMsg = "Chunked response is not parsing large packets efficiently: " . ($time2 / $time1);
+        $this->assertTrue(2 > ($time2 / $time1), $errMsg);
     }
 
     public function testLineBreaksCompatibility()

--- a/test/_files/response_chunked_head
+++ b/test/_files/response_chunked_head
@@ -1,0 +1,6 @@
+Date: Sun, 25 Jun 2006 19:55:19 GMT
+Server: Apache
+X-powered-by: PHP/5.1.4-pl3-gentoo
+Connection: close
+Transfer-encoding: chunked
+Content-type: text/html


### PR DESCRIPTION
In one of our legacy projects we download a ~200MB file in memory using chunked encoding. Calling getBody() on this (which calls decodeChunkedBody()) will take > 5 minutes for processing the response() since creates very inefficient copies of the body with each chunk (substr). 

To make this more efficient we can use the offset parameter, to avoid copying the body during iteration. 

Tests still passed. 
