### PR TITLE
fix header missed value exception

### DIFF
--- a/src/Headers.php
+++ b/src/Headers.php
@@ -179,17 +179,14 @@ class Headers implements Countable, Iterator
      * @param string $fieldValue optional
      * @return Headers
      */
-    public function addHeaderLine($headerFieldNameOrLine, $fieldValue = null)
+    public function addHeaderLine($headerFieldNameOrLine, $fieldValue = '')
     {
         $matches = null;
-        if (preg_match('/^(?P<name>[^()><@,;:\"\\/\[\]?=}{ \t]+):.*$/', $headerFieldNameOrLine, $matches)
-            && $fieldValue === null) {
+        if (preg_match('/^(?P<name>[^()><@,;:\"\\/\[\]?=}{ \t]+):.*$/', $headerFieldNameOrLine, $matches)) {
             // is a header
             $headerName = $matches['name'];
             $headerKey  = static::createKey($matches['name']);
             $line = $headerFieldNameOrLine;
-        } elseif ($fieldValue === null) {
-            throw new Exception\InvalidArgumentException('A field name was provided without a field value');
         } else {
             $headerName = $headerFieldNameOrLine;
             $headerKey  = static::createKey($headerFieldNameOrLine);

--- a/test/HeadersTest.php
+++ b/test/HeadersTest.php
@@ -131,9 +131,8 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Zend\Http\Header\GenericHeader', $headers->get('Fake'));
     }
 
-    public function testHeadersAddHeaderLineThrowsExceptionOnMissingFieldValue()
+    public function testHeadersAddHeaderLineShouldntThrowAnExceptionOnMissedFieldValue()
     {
-        $this->setExpectedException('Zend\Http\Exception\InvalidArgumentException', 'without a field');
         $headers = new Headers();
         $headers->addHeaderLine('Foo');
     }


### PR DESCRIPTION
Headers failing by sending empty "user-agent"
The main issue in Headers::addHeaders
```
if (is_string($value)) {
   $this->addHeaderLine($value);
```
But below in method addHeaderLine signature
```
    public function addHeaderLine($headerFieldNameOrLine, $fieldValue = null)
    {
        $matches = null;
        if (preg_match('/^(?P<name>[^()><@,;:\"\\/\[\]?=}{ \t]+):.*$/', $headerFieldNameOrLine, $matches)
            && $fieldValue === null) {
            // is a header
            $headerName = $matches['name'];
            $headerKey  = static::createKey($matches['name']);
            $line = $headerFieldNameOrLine;
        } elseif ($fieldValue === null) {
            throw new Exception\InvalidArgumentException('A field name was provided without a field value');
        }
```

Witch is wrong typing NULL on string only fields