### PR TITLE
Fixes #95: SetCookie::setMaxAge() null, negative, and non-numeric redefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to this project will be documented in this file, in reverse 
   codes 226, 308, 444, 499, 510, 599 with their corresponding constants and
   reason phrases.
 
+### Changed
+
+- [#120](https://github.com/zendframework/zend-http/pull/120) Changes handling
+  of Cookie Max-Age parameter to conform to specification
+  [rfc6265#section-5.2.2](https://tools.ietf.org/html/rfc6265#section-5.2.2).
+  Specifically, non-numeric values are ignored and negative numbers are changed
+  to 0.
+
 ### Deprecated
 
 - Nothing.

--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -139,7 +139,7 @@ class SetCookie implements MultipleHeaderInterface
                             $header->setVersion((int) $headerValue);
                             break;
                         case 'maxage':
-                            $header->setMaxAge((int) $headerValue);
+                            $header->setMaxAge($headerValue);
                             break;
                         default:
                             // Intentionally omitted
@@ -342,14 +342,19 @@ class SetCookie implements MultipleHeaderInterface
      * Set Max-Age
      *
      * @param int $maxAge
-     * @throws Exception\InvalidArgumentException
      * @return SetCookie
      */
     public function setMaxAge($maxAge)
     {
-        if ($maxAge !== null && (! is_int($maxAge) || ($maxAge < 0))) {
-            throw new Exception\InvalidArgumentException('Invalid Max-Age number specified');
+        if ($maxAge === null || ! is_numeric($maxAge)) {
+            return $this;
         }
+
+        $maxAge = (int) $maxAge;
+        if ($maxAge < 0) {
+            $maxAge = 0;
+        }
+
         $this->maxAge = $maxAge;
         return $this;
     }

--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -350,12 +350,7 @@ class SetCookie implements MultipleHeaderInterface
             return $this;
         }
 
-        $maxAge = (int) $maxAge;
-        if ($maxAge < 0) {
-            $maxAge = 0;
-        }
-
-        $this->maxAge = $maxAge;
+        $this->maxAge = max(0, (int) $maxAge);
         return $this;
     }
 

--- a/test/Header/SetCookieTest.php
+++ b/test/Header/SetCookieTest.php
@@ -661,6 +661,33 @@ class SetCookieTest extends TestCase
                 ],
                 'emptykey=; Domain=docs.foo.com',
             ],
+            [
+                'Set-Cookie: emptykey; Domain=docs.foo.com; Max-Age=foo;',
+                [
+                    'name'    => 'myname',
+                    'value'   => '',
+                    'domain'  => 'docs.foo.com',
+                ],
+                'emptykey=; Domain=docs.foo.com'
+            ],
+            [
+                'Set-Cookie: emptykey; Domain=docs.foo.com; Max-Age=-1480312904;',
+                [
+                    'name'    => 'myname',
+                    'value'   => '',
+                    'domain'  => 'docs.foo.com',
+                ],
+                'emptykey=; Max-Age=0; Domain=docs.foo.com'
+            ],
+            [
+                'Set-Cookie: emptykey; Domain=docs.foo.com; Max-Age=100;',
+                [
+                    'name'    => 'myname',
+                    'value'   => '',
+                    'domain'  => 'docs.foo.com',
+                ],
+                'emptykey=; Max-Age=100; Domain=docs.foo.com'
+            ],
         ];
     }
 }


### PR DESCRIPTION
I hope I don't missreading https://tools.ietf.org/html/rfc6265#section-5.2.2 document

```
if $maxAge = null or "string", ignore
if $maxAge = negative, set maxAge = 0
otherwise, set maxAge = $maxAge
```