### PR TITLE
Avoid opening output stream twice

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -69,6 +69,11 @@ class Client implements Stdlib\DispatchableInterface
     protected $streamName = null;
 
     /**
+     * @var resource|null
+     */
+    protected $streamHandle = null;
+
+    /**
      * @var array of Header\SetCookie
      */
     protected $cookies = [];
@@ -918,11 +923,17 @@ class Client implements Stdlib\DispatchableInterface
                 throw new Client\Exception\RuntimeException('Adapter does not support streaming');
             }
 
+            $this->streamHandle = null;
             // calling protected method to allow extending classes
             // to wrap the interaction with the adapter
             $response = $this->doRequest($uri, $method, $secure, $headers, $body);
+            $stream = $this->streamHandle;
+            $this->streamHandle = null;
 
             if (! $response) {
+                if ($stream !== null) {
+                    fclose($stream);
+                }
                 throw new Exception\RuntimeException('Unable to read response, or response is empty');
             }
 
@@ -933,9 +944,11 @@ class Client implements Stdlib\DispatchableInterface
             }
 
             if ($this->config['outputstream']) {
-                $stream = $this->getStream();
-                if (! is_resource($stream) && is_string($stream)) {
-                    $stream = fopen($stream, 'r');
+                if ($stream === null) {
+                    $stream = $this->getStream();
+                    if (! is_resource($stream) && is_string($stream)) {
+                        $stream = fopen($stream, 'r');
+                    }
                 }
                 $streamMetaData = stream_get_meta_data($stream);
                 if ($streamMetaData['seekable']) {
@@ -1412,8 +1425,8 @@ class Client implements Stdlib\DispatchableInterface
 
         if ($this->config['outputstream']) {
             if ($this->adapter instanceof Client\Adapter\StreamInterface) {
-                $stream = $this->openTempStream();
-                $this->adapter->setOutputStream($stream);
+                $this->streamHandle = $this->openTempStream();
+                $this->adapter->setOutputStream($this->streamHandle);
             } else {
                 throw new Exception\RuntimeException('Adapter does not support streaming');
             }

--- a/test/Client/StaticTest.php
+++ b/test/Client/StaticTest.php
@@ -503,6 +503,36 @@ class StaticTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test if a downloaded file can be deleted
+     *
+     * @group ZF-9685
+     */
+    public function testDownloadedFileCanBeDeleted()
+    {
+        if (! getenv('TESTS_ZEND_HTTP_CLIENT_ONLINE')) {
+            $this->markTestSkipped('Zend\Http\Client online tests are not enabled');
+        }
+        $url = 'http://www.example.com/';
+        $outputFile = @tempnam(@sys_get_temp_dir(), 'zht');
+        if (!is_file($outputFile)) {
+            $this->markTestSkipped('Failed to create a temporary file');
+        }
+        $config = [
+            'outputstream' => $outputFile,
+        ];
+        $client = new HTTPClient($url, $config);
+
+        $result = $client->send();
+
+        $this->assertInstanceOf('Zend\Http\Response\Stream', $result);
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->assertFalse(@unlink($outputFile), 'Deleting an open file should fail on Windows');
+        }
+        fclose($result->getStream());
+        $this->assertTrue(@unlink($outputFile), 'Failed to delete downloaded file');
+    }
+
+    /**
      * Testing if the connection can be closed
      *
      * @group ZF-9685

--- a/test/Client/StaticTest.php
+++ b/test/Client/StaticTest.php
@@ -514,7 +514,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         }
         $url = 'http://www.example.com/';
         $outputFile = @tempnam(@sys_get_temp_dir(), 'zht');
-        if (!is_file($outputFile)) {
+        if (! is_file($outputFile)) {
             $this->markTestSkipped('Failed to create a temporary file');
         }
         $config = [


### PR DESCRIPTION
When we set the `outputstream` option, the output file gets opened twice: [here](https://github.com/zendframework/zend-http/blob/8c23aaae03d9dcb0f2bdb7d3372cc306f411d537/src/Client.php#L722) and [here](https://github.com/zendframework/zend-http/blob/8c23aaae03d9dcb0f2bdb7d3372cc306f411d537/src/Client.php#L938).

The second handle can be managed (eg closed) by accessing the `Zend\Http\Response\Stream\getStream()` method, but the first handle is simply lost: the file remains open (ie locked) until the end of the execution of the PHP script.

Let's reuse the first file handle.