### PR TITLE
Reset previous response headers before curl_exec

### DIFF
--- a/src/Client/Adapter/Curl.php
+++ b/src/Client/Adapter/Curl.php
@@ -437,6 +437,8 @@ class Curl implements HttpAdapter, StreamInterface
             }
         }
 
+        $this->response = '';
+
         // send the request
 
         $response = curl_exec($this->curl);


### PR DESCRIPTION
Using the same client instance, if you perform a normal request and then a request using an output stream, the headers of the first request will be kept, resulting in two set of headers in the second call.

This causes all sort of errors, for instance
```
Too much content was extracted from the stream (X instead of Y bytes)
```