### PR TITLE
Fix unused argument in sprintf expression in CacheControl

### DIFF
--- a/src/Header/CacheControl.php
+++ b/src/Header/CacheControl.php
@@ -39,7 +39,7 @@ class CacheControl implements HeaderInterface
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'cache-control') {
             throw new Exception\InvalidArgumentException(sprintf(
-                'Invalid header line for Cache-Control string: ""',
+                'Invalid header line for Cache-Control string: "%s"',
                 $name
             ));
         }


### PR DESCRIPTION
Not clear on the impact, this was detected via static analysis. (phan/phan)
The thrown exception would always be 'Invalid header line for Cache-Control string: ""'