### PR TITLE
Fluent Stream::setCleanup()

### DIFF
--- a/src/Response/Stream.php
+++ b/src/Response/Stream.php
@@ -113,6 +113,7 @@ class Stream extends Response
     public function setCleanup($cleanup = true)
     {
         $this->cleanup = $cleanup;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Because `Stream::setCleanup()` was not returning `$this`, it was breaking the fluent interface.