### PR TITLE
Fixes #36 Client::setUri() should keep relative uri status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#149](https://github.com/zendframework/zend-http/pull/149) Client::setUri() should keep relative uri status
 
 ## 2.8.0 - 2018-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+[#149](https://github.com/zendframework/zend-http/pull/149) Client::setUri() should keep relative uri status
 
 ## 2.8.2 - 2018-08-13
 
@@ -106,7 +106,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- [#149](https://github.com/zendframework/zend-http/pull/149) Client::setUri() should keep relative uri status
+- Nothing.
 
 ## 2.8.0 - 2018-04-26
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -327,13 +327,13 @@ class Client implements Stdlib\DispatchableInterface
             $uri = $this->getUri();
 
             // Set auth if username and password has been specified in the uri
-            if ($user = $uri->getUser() && $password = $uri->getPassword()) {
+            if (($user = $uri->getUser()) && ($password = $uri->getPassword())) {
                 $this->setAuth($user, $password);
             }
 
             // We have no ports, set the defaults
             if (! $uri->getPort() && $uri->isAbsolute()) {
-                $uri->setPort(($uri->getScheme() == 'https' ? 443 : 80));
+                $uri->setPort($uri->getScheme() === 'https' ? 443 : 80);
             }
         }
         return $this;
@@ -904,7 +904,7 @@ class Client implements Stdlib\DispatchableInterface
             }
             // If we have no ports, set the defaults
             if (! $uri->getPort() && $uri->isAbsolute()) {
-                $uri->setPort($uri->getScheme() == 'https' ? 443 : 80);
+                $uri->setPort($uri->getScheme() === 'https' ? 443 : 80);
             }
 
             // method

--- a/src/Client.php
+++ b/src/Client.php
@@ -324,14 +324,16 @@ class Client implements Stdlib\DispatchableInterface
                 $this->clearAuth();
             }
 
+            $uri = $this->getUri();
+
             // Set auth if username and password has been specified in the uri
-            if ($this->getUri()->getUser() && $this->getUri()->getPassword()) {
-                $this->setAuth($this->getUri()->getUser(), $this->getUri()->getPassword());
+            if ($user = $uri->getUser() && $password = $uri->getPassword()) {
+                $this->setAuth($user, $password);
             }
 
             // We have no ports, set the defaults
-            if (! $this->getUri()->getPort() && $this->getUri()->isAbsolute()) {
-                $this->getUri()->setPort(($this->getUri()->getScheme() == 'https' ? 443 : 80));
+            if (! $uri->getPort() && $uri->isAbsolute()) {
+                $uri->setPort(($uri->getScheme() == 'https' ? 443 : 80));
             }
         }
         return $this;

--- a/src/Client.php
+++ b/src/Client.php
@@ -330,7 +330,7 @@ class Client implements Stdlib\DispatchableInterface
             }
 
             // We have no ports, set the defaults
-            if (! $this->getUri()->getPort()) {
+            if (! $this->getUri()->getPort() && $this->getUri()->isAbsolute()) {
                 $this->getUri()->setPort(($this->getUri()->getScheme() == 'https' ? 443 : 80));
             }
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -903,7 +903,7 @@ class Client implements Stdlib\DispatchableInterface
                 }
             }
             // If we have no ports, set the defaults
-            if (! $uri->getPort()) {
+            if (! $uri->getPort() && $uri->isAbsolute()) {
                 $uri->setPort($uri->getScheme() == 'https' ? 443 : 80);
             }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -325,9 +325,11 @@ class Client implements Stdlib\DispatchableInterface
             }
 
             $uri = $this->getUri();
+            $user = $uri->getUser();
+            $password = $uri->getPassword();
 
             // Set auth if username and password has been specified in the uri
-            if (($user = $uri->getUser()) && ($password = $uri->getPassword())) {
+            if ($user && $password) {
                 $this->setAuth($user, $password);
             }
 

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -540,21 +540,40 @@ class ClientTest extends TestCase
     {
         $client = new Client($uri);
         $this->assertSame($isValidRelativeURI, $client->getUri()->isValidRelative());
+
+        $client->setAdapter(Test::class);
+        $client->send();
+        $this->assertSame($isValidRelativeURI, $client->getUri()->isValidRelative());
     }
 
-    public function testSendRequestWithRelativeURI()
+    public function portChangeDataProvider()
+    {
+        return [
+            ['https://localhost/example', 443],
+            ['http://localhost/example', 80]
+        ];
+    }
+
+    /**
+     * @dataProvider portChangeDataProvider
+     */
+    public function testAbsoluteSetPort443OnHttps($absoluteURI, $port)
+    {
+        $client = new Client($absoluteURI);
+        $this->assertSame($port, $client->getUri()->getPort());
+
+        $client->setAdapter(Test::class);
+        $client->send();
+        $this->assertSame($port, $client->getUri()->getPort());
+    }
+
+    public function testRelativeURIDoesnotSetPort()
     {
         $client = new Client('/example');
-        $client->setAdapter(Test::class);
-        $client->send();
-        $this->assertTrue($client->getUri()->isValidRelative());
-    }
+        $this->assertSame(null, $client->getUri()->getPort());
 
-    public function testSendRequestWithAbsoluteURI()
-    {
-        $client = new Client('http://localhost/example');
         $client->setAdapter(Test::class);
         $client->send();
-        $this->assertFalse($client->getUri()->isValidRelative());
+        $this->assertSame(null, $client->getUri()->getPort());
     }
 }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -524,4 +524,21 @@ class ClientTest extends TestCase
         $rawRequest = $client->getLastRawRequest();
         $this->assertContains('foo=bar&baz=foo', $rawRequest);
     }
+
+    public function uriDataProvider()
+    {
+        return [
+            ['example', true],
+            ['http://localhost/example', false]
+        ];
+    }
+
+    /**
+     * @dataProvider uriDataProvider
+     */
+    public function testValidRelativeURI($uri, $isValidRelativeURI)
+    {
+        $client = new Client($uri);
+        $this->assertSame($isValidRelativeURI, $client->getUri()->isValidRelative());
+    }
 }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -559,8 +559,10 @@ class ClientTest extends TestCase
      */
     public function testAbsoluteSetPortWhenNoPort($absoluteURI, $port)
     {
-        $client = new Client($absoluteURI);
+        $client = new Client();
         $client->getUri()->setPort(null);
+
+        $client->setUri($absoluteURI);
         $this->assertSame($port, $client->getUri()->getPort());
 
         $client->setAdapter(Test::class);

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -541,4 +541,11 @@ class ClientTest extends TestCase
         $client = new Client($uri);
         $this->assertSame($isValidRelativeURI, $client->getUri()->isValidRelative());
     }
+
+    public function testSendRequestWithRelativeURI()
+    {
+        $client = new Client('/example');
+        $client->setAdapter(Test::class);
+        $client->send();
+    }
 }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -557,9 +557,10 @@ class ClientTest extends TestCase
     /**
      * @dataProvider portChangeDataProvider
      */
-    public function testAbsoluteSetPort443OnHttps($absoluteURI, $port)
+    public function testAbsoluteSetPortWhenNoPort($absoluteURI, $port)
     {
         $client = new Client($absoluteURI);
+        $client->setPort(null);
         $this->assertSame($port, $client->getUri()->getPort());
 
         $client->setAdapter(Test::class);

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -528,8 +528,8 @@ class ClientTest extends TestCase
     public function uriDataProvider()
     {
         return [
-            ['/example', true],
-            ['http://localhost/example', false]
+            ['valid-relative' => ['/example', true]],
+            ['invalid-absolute' => ['http://localhost/example', false]]
         ];
     }
 

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -528,7 +528,7 @@ class ClientTest extends TestCase
     public function uriDataProvider()
     {
         return [
-            ['example', true],
+            ['/example', true],
             ['http://localhost/example', false]
         ];
     }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -557,7 +557,7 @@ class ClientTest extends TestCase
     /**
      * @dataProvider portChangeDataProvider
      */
-    public function testUriPortIsSetToAppropriateDefaultValueWhenAnAbsoluteUriOmittingThePortIsProvided($absoluteURI, $port)
+    public function testUriPortIsSetToAppropriateDefaultValueWhenAnUriOmittingThePortIsProvided($absoluteURI, $port)
     {
         $client = new Client();
         $client->getUri()->setPort(null);

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -528,8 +528,8 @@ class ClientTest extends TestCase
     public function uriDataProvider()
     {
         return [
-            ['valid-relative' => ['/example', true]],
-            ['invalid-absolute' => ['http://localhost/example', false]]
+            'valid-relative' => ['/example', true],
+            'invalid-absolute' => ['http://localhost/example', false],
         ];
     }
 
@@ -549,8 +549,8 @@ class ClientTest extends TestCase
     public function portChangeDataProvider()
     {
         return [
-            ['https://localhost/example', 443],
-            ['http://localhost/example', 80]
+            'default-https' => ['https://localhost/example', 443],
+            'default-http' => ['http://localhost/example', 80]
         ];
     }
 

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -536,7 +536,7 @@ class ClientTest extends TestCase
     /**
      * @dataProvider uriDataProvider
      */
-    public function testValidRelativeURI($uri, $isValidRelativeURI)
+    public function testUriCorrectlyDeterminesWhetherOrNotItIsAValidRelativeUri($uri, $isValidRelativeURI)
     {
         $client = new Client($uri);
         $this->assertSame($isValidRelativeURI, $client->getUri()->isValidRelative());

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -570,10 +570,10 @@ class ClientTest extends TestCase
     public function testRelativeURIDoesnotSetPort()
     {
         $client = new Client('/example');
-        $this->assertSame(null, $client->getUri()->getPort());
+        $this->assertNull($client->getUri()->getPort());
 
         $client->setAdapter(Test::class);
         $client->send();
-        $this->assertSame(null, $client->getUri()->getPort());
+        $this->assertNull($client->getUri()->getPort());
     }
 }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -570,7 +570,7 @@ class ClientTest extends TestCase
         $this->assertSame($port, $client->getUri()->getPort());
     }
 
-    public function testRelativeURIDoesnotSetPort()
+    public function testUriPortIsNotSetWhenUriIsRelative()
     {
         $client = new Client('/example');
         $this->assertNull($client->getUri()->getPort());

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -547,5 +547,6 @@ class ClientTest extends TestCase
         $client = new Client('/example');
         $client->setAdapter(Test::class);
         $client->send();
+        $this->assertTrue($client->getUri()->isValidRelative());
     }
 }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -560,7 +560,7 @@ class ClientTest extends TestCase
     public function testAbsoluteSetPortWhenNoPort($absoluteURI, $port)
     {
         $client = new Client($absoluteURI);
-        $client->setPort(null);
+        $client->getUri()->setPort(null);
         $this->assertSame($port, $client->getUri()->getPort());
 
         $client->setAdapter(Test::class);

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -549,4 +549,12 @@ class ClientTest extends TestCase
         $client->send();
         $this->assertTrue($client->getUri()->isValidRelative());
     }
+
+    public function testSendRequestWithAbsoluteURI()
+    {
+        $client = new Client('http://localhost/example');
+        $client->setAdapter(Test::class);
+        $client->send();
+        $this->assertFalse($client->getUri()->isValidRelative());
+    }
 }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -557,7 +557,7 @@ class ClientTest extends TestCase
     /**
      * @dataProvider portChangeDataProvider
      */
-    public function testAbsoluteSetPortWhenNoPort($absoluteURI, $port)
+    public function testUriPortIsSetToAppropriateDefaultValueWhenAnAbsoluteUriOmittingThePortIsProvided($absoluteURI, $port)
     {
         $client = new Client();
         $client->getUri()->setPort(null);


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
          Supply relative uri to `Client::setUri()`
  - [x] Detail the original, incorrect behavior.
          It convert to absolute uri
  - [x] Detail the new, expected behavior.
          It should keep as relative uri 
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.

