### PR TITLE
Passing an invalid uri to the referrer header should no longer throw

### DIFF
--- a/src/Header/AbstractLocation.php
+++ b/src/Header/AbstractLocation.php
@@ -76,6 +76,12 @@ abstract class AbstractLocation implements HeaderInterface
                     $e->getCode(),
                     $e
                 );
+            } catch (UriException\InvalidArgumentException $e) {
+                throw new Exception\InvalidArgumentException(
+                    sprintf('Invalid URI passed as string (%s)', (string) $uri),
+                    $e->getCode(),
+                    $e
+                );
             }
         } elseif (! ($uri instanceof UriInterface)) {
             throw new Exception\InvalidArgumentException('URI must be an instance of Zend\Uri\Http or a string');

--- a/test/Header/RefererTest.php
+++ b/test/Header/RefererTest.php
@@ -77,4 +77,17 @@ class RefererTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         Referer::fromString("Referer: http://www.example.com/\r\n\r\nevilContent");
     }
+
+    public function testInvalidUriShouldWrapException()
+    {
+        $headerString = "Referer: unknown-scheme://test";
+
+        $headers = \Zend\Http\Headers::fromString($headerString);
+
+        $result = $headers->get('Referer');
+
+        $this->assertInstanceOf(\Zend\Http\Header\GenericHeader::class, $result);
+        $this->assertNotInstanceOf(\Zend\Http\Header\Referer::class, $result);
+        $this->assertEquals('unknown-scheme://test', $result->getFieldValue());
+    }
 }


### PR DESCRIPTION
Due to the change in https://github.com/zendframework/zend-http/pull/147 we removed the try/catch control structures from our code. However: exceptions are still generated. I think that this is not intended.

The only valid way to check for a referrer is now the following. Which is kind of cumbersome:
```php
function isRefererFromGitHub($headers) {
    try {
        $referer = $headers->get('Referer');
        if (!$referer instanceof \Zend\Http\Header\GenericHeader) {
            return false;
        }
        
        return $referer->getUri()->getHost() === 'github.com';
    } catch (\Zend\Http\Header\Exception\InvalidArgumentException $e) {
        return false;
    }
}
```

This PR fixes this by wrapping the exception generated. 

----

I am however a bit unsure if this is correct. The release notes state:

> Now, Header::has() will return false for such headers

However; in my case the `has` function _does_ yield true. Therefore I omitted that assertion from my test code.

Any thoughts @webimpress @weierophinney?