### PR TITLE
using "Cookie|false" instead of "Cookie|bool" for docblock Request::getCookie()

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -314,7 +314,7 @@ class Request extends AbstractMessage implements RequestInterface
      * Return the Cookie header, this is the same as calling $request->getHeaders()->get('Cookie');
      *
      * @convenience $request->getHeaders()->get('Cookie');
-     * @return Header\Cookie|bool
+     * @return Header\Cookie|false
      */
     public function getCookie()
     {


### PR DESCRIPTION
- [x] Is this related to quality assurance?
- [x] Is this related to documentation?

As when no "Cookie" header, it will return false.