### PR TITLE
#127 Set-Cookie: added ability to set value without URL encoding

### DIFF
--- a/src/Header/Cookie.php
+++ b/src/Header/Cookie.php
@@ -75,12 +75,20 @@ class Cookie extends ArrayObject implements HeaderInterface
         parent::__construct($array, ArrayObject::ARRAY_AS_PROPS);
     }
 
+    /**
+     * @param bool $encodeValue
+     *
+     * @return $this
+     */
     public function setEncodeValue($encodeValue)
     {
         $this->encodeValue = (bool) $encodeValue;
         return $this;
     }
 
+    /**
+     * @return bool
+     */
     public function getEncodeValue()
     {
         return $this->encodeValue;

--- a/test/Header/SetCookieTest.php
+++ b/test/Header/SetCookieTest.php
@@ -50,6 +50,14 @@ class SetCookieTest extends TestCase
         $this->assertEquals('myname=quotedValue', $setCookieHeader->getFieldValue());
     }
 
+    public function testSetCookieFromStringWithNotEncodedValue()
+    {
+        $setCookieHeader = SetCookie::fromString('Set-Cookie: foo=a:b; Path=/');
+        $this->assertFalse($setCookieHeader->getEncodeValue());
+        $this->assertEquals('a:b', $setCookieHeader->getValue());
+        $this->assertEquals('foo=a:b; Path=/', $setCookieHeader->getFieldValue());
+    }
+
     public function testSetCookieFromStringCreatesValidSetCookieHeader()
     {
         $setCookieHeader = SetCookie::fromString('Set-Cookie: xxx');
@@ -455,6 +463,25 @@ class SetCookieTest extends TestCase
         $header = new SetCookie('leo_auth_token');
         $header->setValue("example\r\n\r\nevilContent");
         $this->assertEquals('Set-Cookie: leo_auth_token=example%0D%0A%0D%0AevilContent', $header->toString());
+    }
+
+    public function testSetCookieWithEncodeValue()
+    {
+        $header = new SetCookie('test');
+        $header->setValue('a:b');
+
+        $this->assertSame('a:b', $header->getValue());
+        $this->assertSame('test=a%3Ab', $header->getFieldValue());
+    }
+
+    public function testSetCookieWithNoEncodeValue()
+    {
+        $header = new SetCookie('test');
+        $header->setValue('a:b');
+        $header->setEncodeValue(false);
+
+        $this->assertSame('a:b', $header->getValue());
+        $this->assertSame('test=a:b', $header->getFieldValue());
     }
 
     public function setterInjections()


### PR DESCRIPTION
#127 
- Added `Added Zend\Http\Header\SetCookie::setEncodeValue()` and `Added Zend\Http\Header\SetCookie::setEncodeValue()` to allow set value without url encoding