### PR TITLE
#76 Check content-length before to decode response body

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -564,6 +564,11 @@ class Response extends AbstractMessage implements ResponseInterface
             );
         }
 
+        if ($this->getHeaders()->has('content-length')
+            && 0 === (int) $this->getHeaders()->get('content-length')->getFieldValue()) {
+            return '';
+        }
+
         ErrorHandler::start();
         $return = gzinflate(substr($body, 10));
         $test = ErrorHandler::stop();
@@ -592,6 +597,11 @@ class Response extends AbstractMessage implements ResponseInterface
             throw new Exception\RuntimeException(
                 'zlib extension is required in order to decode "deflate" encoding'
             );
+        }
+
+        if ($this->getHeaders()->has('content-length')
+            && 0 === (int) $this->getHeaders()->get('content-length')->getFieldValue()) {
+            return '';
         }
 
         /**

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -125,6 +125,28 @@ class ResponseTest extends TestCase
         $this->assertEquals('f24dd075ba2ebfb3bf21270e3fdc5303', md5($res->getContent()));
     }
 
+    public function testGzipResponseWithEmptyBody()
+    {
+        $responseTest = <<<'REQ'
+HTTP/1.1 200 OK
+Date: Sun, 25 Jun 2006 19:36:47 GMT
+Server: Apache
+X-powered-by: PHP/5.1.4-pl3-gentoo
+Content-encoding: gzip
+Vary: Accept-Encoding
+Content-length: 0
+Connection: close
+Content-type: text/html
+
+REQ;
+
+        $res = Response::fromString($responseTest);
+
+        $this->assertEquals('gzip', $res->getHeaders()->get('Content-encoding')->getFieldValue());
+        $this->assertSame('', $res->getBody());
+        $this->assertSame('', $res->getContent());
+    }
+
     public function testDeflateResponse()
     {
         $responseTest = file_get_contents(__DIR__ . '/_files/response_deflate');
@@ -134,6 +156,28 @@ class ResponseTest extends TestCase
         $this->assertEquals('deflate', $res->getHeaders()->get('Content-encoding')->getFieldValue());
         $this->assertEquals('0b13cb193de9450aa70a6403e2c9902f', md5($res->getBody()));
         $this->assertEquals('ad62c21c3aa77b6a6f39600f6dd553b8', md5($res->getContent()));
+    }
+
+    public function testDeflateResponseWithEmptyBody()
+    {
+        $responseTest = <<<'REQ'
+HTTP/1.1 200 OK
+Date: Sun, 25 Jun 2006 19:38:02 GMT
+Server: Apache
+X-powered-by: PHP/5.1.4-pl3-gentoo
+Content-encoding: deflate
+Vary: Accept-Encoding
+Content-length: 0
+Connection: close
+Content-type: text/html
+
+REQ;
+
+        $res = Response::fromString($responseTest);
+
+        $this->assertEquals('deflate', $res->getHeaders()->get('Content-encoding')->getFieldValue());
+        $this->assertSame('', $res->getBody());
+        $this->assertSame('', $res->getContent());
     }
 
     /**


### PR DESCRIPTION
With this PR we check the content-length header, if it's 0 we didn't try to decode content body.