### PR TITLE
phpstan fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   global:
     - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
+    - PHPSTAN_DEPS="phpstan/phpstan:^0.12"
     - TESTS_ZEND_HTTP_CLIENT_ONLINE=true
     - TESTS_ZEND_HTTP_CLIENT_BASEURI=http://127.0.0.1
     - TESTS_ZEND_HTTP_CLIENT_HTTP_PROXY=127.0.0.1:8081
@@ -43,6 +44,7 @@ matrix:
         - DEPS=locked
         - CS_CHECK=true
         - TEST_COVERAGE=true
+        - PHPSTAN_TEST=true
     - php: 7.1
       env:
         - DEPS=latest
@@ -74,6 +76,7 @@ install:
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
+  - if [[ $PHPSTAN_TEST == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $PHPSTAN_DEPS ; fi
   - stty cols 120 && composer show
 
 before_script:
@@ -105,6 +108,7 @@ before_script:
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
+  - if [[ $PHPSTAN_TEST == 'true' ]]; then ./vendor/bin/phpstan analyse --no-progress . ; fi
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry php vendor/bin/php-coveralls -v ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- Relative URIs are not allowed anymore in `Zend\Http\Client`.
+  Anyway, usage of relative URIs has no sense and no adapter can handle it.
 
 ### Deprecated
 
-- Nothing
+- Nothing.
 
 ### Removed
 
@@ -24,6 +25,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - Fixed `Zend\Http\Cookies::getAllCookies(Zend\Http\Cookies::COOKIE_STRING_ARRAY)`.
 - Fixed `Zend\Http\Cookies::getAllCookies(Zend\Http\Cookies::COOKIE_STRING_CONCAT)`.
+- Fixed use of HTTP URIs with empty path in Request
 
 ## 2.11.1 - TBD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
+- `Zend\Http\Request`'s URI now always have a default path ´/´ even when a `Zend\Uri\Http`
+  object is provided with no path.
 - Relative URIs are not allowed anymore in `Zend\Http\Client`.
   Anyway, usage of relative URIs has no sense and no adapter can handle it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Deprecated
 
-- Nothing.
+- Nothing
 
 ### Removed
 
@@ -22,7 +22,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- Fixed `Zend\Http\Cookies::getAllCookies(Zend\Http\Cookies::COOKIE_STRING_ARRAY)`.
+- Fixed `Zend\Http\Cookies::getAllCookies(Zend\Http\Cookies::COOKIE_STRING_CONCAT)`.
 
 ## 2.11.1 - TBD
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -43,3 +43,4 @@ parameters:
         -
             message: '#Else branch is unreachable because previous condition is always true#'
             path: %currentWorkingDirectory%/src/Client.php
+        - '#Access to an undefined property object::\$.+#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,18 @@
+parameters:
+    level: max
+
+    excludes_analyse:
+        - %currentWorkingDirectory%/docs/*
+        - %currentWorkingDirectory%/test/*
+        - %currentWorkingDirectory%/vendor/*
+
+    universalObjectCratesClasses:
+        - Zend\Http\Header\Accept\FieldValuePart\AbstractFieldValuePart
+
+    ignoreErrors:
+        - "#Casting to [a-z]+ something that's already [a-z]+#"
+        - "#Negated boolean is always false#"
+        - "#Result of && is always false#"
+        - "#Strict comparison using === between 8 and 4 will always evaluate to false#"
+        - '#Parameter \#1 $port of method Zend\\Uri\\Uri::setPort() expects int, int|null given#'
+        - '#Access to an undefined property object::\$params#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,9 +10,36 @@ parameters:
         - Zend\Http\Header\Accept\FieldValuePart\AbstractFieldValuePart
 
     ignoreErrors:
-        - "#Casting to [a-z]+ something that's already [a-z]+#"
-        - "#Negated boolean is always false#"
-        - "#Result of && is always false#"
-        - "#Strict comparison using === between 8 and 4 will always evaluate to false#"
-        - '#Parameter \#1 $port of method Zend\\Uri\\Uri::setPort() expects int, int|null given#'
-        - '#Access to an undefined property object::\$params#'
+        -
+            message: '#Else branch is unreachable because ternary operator condition is always true#'
+            path: %currentWorkingDirectory%/src/Response.php
+        -
+            message: '#Result of && is always false#'
+            path: %currentWorkingDirectory%/src/PhpEnvironment/Request.php
+        -
+            message: '#Parameter \#1 $port of method Zend\\Uri\\Uri::setPort\(\) expects int, int|null given#'
+            path: %currentWorkingDirectory%/src/PhpEnvironment/Request.php
+        -
+            message: '#Result of && is always false#'
+            path: %currentWorkingDirectory%/src/Headers.php
+        -
+            message: '#Parameter \#1 \$fragment of method Zend\\Uri\\UriInterface::setFragment\(\) expects string, null given#'
+            path: %currentWorkingDirectory%/src/Header/Referer.php
+        -
+            message: '#Strict comparison using === between DateTime|string and 0 will always evaluate to false#'
+            path: %currentWorkingDirectory%/src/Header/Expires.php
+        -
+            message: '#Return type \(int\) of method Zend\\Http\\Header\\Age::getFieldValue\(\) should be compatible with return type \(string\) of method Zend\\Http\\Header\\HeaderInterface::getFieldValue\(\)#'
+            path: %currentWorkingDirectory%/src/Header/Age.php
+        -
+            message: '#Result of && is always false#'
+            path: %currentWorkingDirectory%/src/Header/Age.php
+        -
+            message: '#Access to an undefined property object::\$params#'
+            path: %currentWorkingDirectory%/src/Header/AbstractAccept.php
+        -
+            message: '#Negated boolean expression is always false#'
+            path: %currentWorkingDirectory%/src/Client/Adapter/Curl.php
+        -
+            message: '#Else branch is unreachable because previous condition is always true#'
+            path: %currentWorkingDirectory%/src/Client.php

--- a/src/AbstractMessage.php
+++ b/src/AbstractMessage.php
@@ -30,7 +30,7 @@ abstract class AbstractMessage extends Message
     protected $version = self::VERSION_11;
 
     /**
-     * @var Headers|null
+     * @var Headers|string|null
      */
     protected $headers;
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -1329,7 +1329,7 @@ class Client implements Stdlib\DispatchableInterface
             }
         } else {
             $contentType = $this->getHeader('Content-Type');
-            $this->setEncType(\is_string($contentType) && ! empty($contentType) ? $contentType: null);
+            $this->setEncType(\is_string($contentType) ? $contentType : '');
         }
 
         // If we have POST parameters or files, encode and add them to the body

--- a/src/Client.php
+++ b/src/Client.php
@@ -1028,7 +1028,7 @@ class Client implements Stdlib\DispatchableInterface
 
             // Get the cookies from response (if any)
             $setCookies = $response->getCookie();
-            if (! \is_bool($setCookies) && ! empty($setCookies)) {
+            if (! is_bool($setCookies) && ! empty($setCookies)) {
                 $this->addCookie($setCookies);
             }
 
@@ -1329,7 +1329,7 @@ class Client implements Stdlib\DispatchableInterface
             }
         } else {
             $contentType = $this->getHeader('Content-Type');
-            $this->setEncType(\is_string($contentType) ? $contentType : '');
+            $this->setEncType(is_string($contentType) ? $contentType : '');
         }
 
         // If we have POST parameters or files, encode and add them to the body

--- a/src/Client.php
+++ b/src/Client.php
@@ -11,6 +11,11 @@ use ArrayIterator;
 use Traversable;
 use Zend\Http\Client\Adapter\Curl;
 use Zend\Http\Client\Adapter\Socket;
+use Zend\Http\Client\Adapter\StreamInterface;
+use Zend\Http\Exception\InvalidArgumentException;
+use Zend\Http\Exception\RuntimeException;
+use Zend\Http\Exception\UnexpectedValueException;
+use Zend\Http\Header\HeaderInterface;
 use Zend\Http\Header\SetCookie;
 use Zend\Stdlib;
 use Zend\Stdlib\ArrayUtils;
@@ -45,17 +50,17 @@ class Client implements Stdlib\DispatchableInterface
     const DIGEST_CNONCE = 'cnonce';
 
     /**
-     * @var Response
+     * @var null|Response
      */
     protected $response;
 
     /**
-     * @var Request
+     * @var null|Request
      */
     protected $request;
 
     /**
-     * @var Client\Adapter\AdapterInterface
+     * @var null|Client\Adapter\AdapterInterface
      */
     protected $adapter;
 
@@ -65,14 +70,14 @@ class Client implements Stdlib\DispatchableInterface
     protected $auth = [];
 
     /**
-     * @var string
+     * @var null|string|resource
      */
     protected $streamName;
 
     /**
      * @var resource|null
      */
-    protected $streamHandle = null;
+    protected $streamHandle;
 
     /**
      * @var array of Header\SetCookie
@@ -85,12 +90,12 @@ class Client implements Stdlib\DispatchableInterface
     protected $encType = '';
 
     /**
-     * @var Request
+     * @var null|string
      */
     protected $lastRawRequest;
 
     /**
-     * @var Response
+     * @var null|string
      */
     protected $lastRawResponse;
 
@@ -128,15 +133,15 @@ class Client implements Stdlib\DispatchableInterface
      * This variable is populated the first time _detectFileMimeType is called
      * and is then reused on every call to this method
      *
-     * @var resource
+     * @var null|resource
      */
     protected static $fileInfoDb;
 
     /**
      * Constructor
      *
-     * @param string $uri
-     * @param array|Traversable $options
+     * @param null|string $uri
+     * @param null|array|Traversable $options
      */
     public function __construct($uri = null, $options = null)
     {
@@ -170,9 +175,7 @@ class Client implements Stdlib\DispatchableInterface
         }
 
         // Pass configuration options to the adapter if it exists
-        if ($this->adapter instanceof Client\Adapter\AdapterInterface) {
-            $this->adapter->setOptions($options);
-        }
+        $this->getAdapter()->setOptions($options);
 
         return $this;
     }
@@ -203,9 +206,12 @@ class Client implements Stdlib\DispatchableInterface
         }
 
         $this->adapter = $adapter;
+
         $config = $this->config;
         unset($config['adapter']);
-        $this->adapter->setOptions($config);
+
+        $adapter->setOptions($config);
+
         return $this;
     }
 
@@ -220,7 +226,10 @@ class Client implements Stdlib\DispatchableInterface
             $this->setAdapter($this->config['adapter']);
         }
 
-        return $this->adapter;
+        /** @var Client\Adapter\AdapterInterface $adapter */
+        $adapter = $this->adapter;
+
+        return $adapter;
     }
 
     /**
@@ -277,7 +286,7 @@ class Client implements Stdlib\DispatchableInterface
     /**
      * Get the last request (as a string)
      *
-     * @return string
+     * @return null|string
      */
     public function getLastRawRequest()
     {
@@ -287,7 +296,7 @@ class Client implements Stdlib\DispatchableInterface
     /**
      * Get the last response (as a string)
      *
-     * @return string
+     * @return null|string
      */
     public function getLastRawResponse()
     {
@@ -314,13 +323,14 @@ class Client implements Stdlib\DispatchableInterface
     {
         if (! empty($uri)) {
             // remember host of last request
-            $lastHost = $this->getRequest()->getUri()->getHost();
+            $lastHost = $this->getRequest()->getUri()->getHost() ?: '';
             $this->getRequest()->setUri($uri);
 
             // if host changed, the HTTP authentication should be cleared for security
             // reasons, see #4215 for a discussion - currently authentication is also
             // cleared for peer subdomains due to technical limits
             $nextHost = $this->getRequest()->getUri()->getHost();
+
             if (! preg_match('/' . preg_quote($lastHost, '/') . '$/i', $nextHost)) {
                 $this->clearAuth();
             }
@@ -412,7 +422,7 @@ class Client implements Stdlib\DispatchableInterface
     {
         $argSeparator = $this->config['argseparator'];
         if (empty($argSeparator)) {
-            $argSeparator = ini_get('arg_separator.output');
+            $argSeparator = ini_get('arg_separator.output') ?: '&';
             $this->setArgSeparator($argSeparator);
         }
         return $argSeparator;
@@ -421,14 +431,14 @@ class Client implements Stdlib\DispatchableInterface
     /**
      * Set the encoding type and the boundary (if any)
      *
-     * @param string $encType
-     * @param string $boundary
+     * @param null|string $encType
+     * @param null|string $boundary
      * @return $this
      */
     public function setEncType($encType, $boundary = null)
     {
         if (null === $encType || empty($encType)) {
-            $this->encType = null;
+            $this->encType = '';
             return $this;
         }
 
@@ -490,10 +500,9 @@ class Client implements Stdlib\DispatchableInterface
      * Reset all the HTTP parameters (request, response, etc)
      *
      * @param  bool   $clearCookies  Also clear all valid cookies? (defaults to false)
-     * @param  bool   $clearAuth     Also clear http authentication? (defaults to true)
      * @return $this
      */
-    public function resetParameters($clearCookies = false /*, $clearAuth = true */)
+    public function resetParameters($clearCookies = false)
     {
         $clearAuth = true;
         if (func_num_args() > 1) {
@@ -503,7 +512,7 @@ class Client implements Stdlib\DispatchableInterface
         $uri = $this->getUri();
 
         $this->streamName      = null;
-        $this->encType         = null;
+        $this->encType         = '';
         $this->request         = null;
         $this->response        = null;
         $this->lastRawRequest  = null;
@@ -535,12 +544,12 @@ class Client implements Stdlib\DispatchableInterface
     /**
      * Get the cookie Id (name+domain+path)
      *
-     * @param  Header\SetCookie|Header\Cookie $cookie
+     * @param  Header\SetCookie $cookie
      * @return string|bool
      */
     protected function getCookieId($cookie)
     {
-        if (($cookie instanceof Header\SetCookie) || ($cookie instanceof Header\Cookie)) {
+        if ($cookie instanceof Header\SetCookie) {
             return $cookie->getName() . $cookie->getDomain() . $cookie->getPath();
         }
         return false;
@@ -550,14 +559,14 @@ class Client implements Stdlib\DispatchableInterface
      * Add a cookie
      *
      * @param array|ArrayIterator|Header\SetCookie|string $cookie
-     * @param string  $value
-     * @param string  $expire
-     * @param string  $path
-     * @param string  $domain
-     * @param  bool $secure
-     * @param  bool $httponly
-     * @param string  $maxAge
-     * @param string  $version
+     * @param null|string  $value
+     * @param null|string  $expire
+     * @param null|string  $path
+     * @param null|string  $domain
+     * @param bool $secure
+     * @param bool $httponly
+     * @param null|int  $maxAge
+     * @param null|int  $version
      * @throws Exception\InvalidArgumentException
      * @return $this
      */
@@ -681,12 +690,16 @@ class Client implements Stdlib\DispatchableInterface
     {
         $headers = $this->getRequest()->getHeaders();
 
-        if ($headers instanceof Headers) {
-            if ($headers->get($name)) {
-                return $headers->get($name)->getFieldValue();
-            }
+        if (! $headers instanceof Headers) {
+            return false;
         }
-        return false;
+
+        $header = $headers->get($name);
+        if (! $header instanceof HeaderInterface) {
+            return false;
+        }
+
+        return $header->getFieldValue();
     }
 
     /**
@@ -703,7 +716,7 @@ class Client implements Stdlib\DispatchableInterface
 
     /**
      * Get status of streaming for received data
-     * @return bool|string
+     * @return bool|resource|string
      */
     public function getStream()
     {
@@ -729,7 +742,11 @@ class Client implements Stdlib\DispatchableInterface
             $this->streamName = tempnam(
                 isset($this->config['streamtmpdir']) ? $this->config['streamtmpdir'] : sys_get_temp_dir(),
                 Client::class
-            );
+            ) ?: null;
+
+            if (null === $this->streamName) {
+                throw new RuntimeException('Unable to create temporary name for stream');
+            }
         }
 
         ErrorHandler::start();
@@ -838,6 +855,8 @@ class Client implements Stdlib\DispatchableInterface
                         );
                     }
                     $ha2 = md5($this->getMethod() . ':' . $this->getUri()->getPath() . ':' . md5($entityBody));
+                } else {
+                    throw new InvalidArgumentException('Invalid DIGEST auth data');
                 }
                 if (empty($digest['qop'])) {
                     $response = md5($ha1 . ':' . $digest['nonce'] . ':' . $ha2);
@@ -855,10 +874,15 @@ class Client implements Stdlib\DispatchableInterface
      *
      * @param Stdlib\RequestInterface $request
      * @param Stdlib\ResponseInterface $response
+     * @throws UnexpectedValueException on $request not an instance of Zend\http\Request
      * @return Stdlib\ResponseInterface
      */
     public function dispatch(Stdlib\RequestInterface $request, Stdlib\ResponseInterface $response = null)
     {
+        if (! $request instanceof Request) {
+            throw UnexpectedValueException::unexpectedType(Request::class, $request);
+        }
+
         return $this->send($request);
     }
 
@@ -925,7 +949,11 @@ class Client implements Stdlib\DispatchableInterface
             // headers
             $headers = $this->prepareHeaders($body, $uri);
 
-            $secure = $uri->getScheme() == 'https';
+            $secure = $uri->getScheme() === 'https';
+
+            if (null === $uri->getHost()) {
+                throw new InvalidArgumentException('Invalid URI in request');
+            }
 
             // cookies
             $cookie = $this->prepareCookies($uri->getHost(), $uri->getPath(), $secure);
@@ -933,15 +961,11 @@ class Client implements Stdlib\DispatchableInterface
                 $headers['Cookie'] = $cookie->getFieldValue();
             }
 
-            // check that adapter supports streaming before using it
-            if (is_resource($body) && ! ($adapter instanceof Client\Adapter\StreamInterface)) {
-                throw new Client\Exception\RuntimeException('Adapter does not support streaming');
-            }
-
             $this->streamHandle = null;
             // calling protected method to allow extending classes
             // to wrap the interaction with the adapter
             $response = $this->doRequest($uri, $method, $secure, $headers, $body);
+            /** @var null|resource $stream */
             $stream = $this->streamHandle;
             $this->streamHandle = null;
 
@@ -959,19 +983,36 @@ class Client implements Stdlib\DispatchableInterface
             }
 
             if ($this->config['outputstream']) {
+                if (! $adapter instanceof StreamInterface) {
+                    throw new Client\Exception\RuntimeException('Adapter does not support streaming');
+                }
+
                 if ($stream === null) {
+                    // @todo: check if it's really used
                     $stream = $this->getStream();
                     if (! is_resource($stream) && is_string($stream)) {
-                        $stream = fopen($stream, 'r');
+                        $stream = fopen($stream, 'rb');
                     }
                 }
+
+                if (! is_resource($stream)) {
+                    throw new UnexpectedValueException('Stream is not a resource');
+                }
+
                 $streamMetaData = stream_get_meta_data($stream);
                 if ($streamMetaData['seekable']) {
                     rewind($stream);
                 }
+
                 // cleanup the adapter
                 $adapter->setOutputStream(null);
                 $response = Response\Stream::fromStream($response, $stream);
+
+                // streamName can just be a string at this point
+                if (! is_string($this->streamName)) {
+                    throw new UnexpectedValueException('Unexpected value for streamName');
+                }
+
                 $response->setStreamName($this->streamName);
                 if (! is_string($this->config['outputstream'])) {
                     // we used temp name, will need to clean up
@@ -983,15 +1024,20 @@ class Client implements Stdlib\DispatchableInterface
 
             // Get the cookies from response (if any)
             $setCookies = $response->getCookie();
-            if (! empty($setCookies)) {
+            if (! \is_bool($setCookies) && ! empty($setCookies)) {
                 $this->addCookie($setCookies);
             }
 
+            /** @var Headers $responseHeaders */
+            $responseHeaders = $response->getHeaders();
+
             // If we got redirected, look for the Location header
-            if ($response->isRedirect() && ($response->getHeaders()->has('Location'))) {
+            if ($response->isRedirect() && ($responseHeaders->has('Location'))) {
                 // Avoid problems with buggy servers that add whitespace at the
                 // end of some headers
-                $location = trim($response->getHeaders()->get('Location')->getFieldValue());
+                /** @var HeaderInterface $locationHeader */
+                $locationHeader = $responseHeaders->get('Location');
+                $location = trim($locationHeader->getFieldValue());
 
                 // Check whether we send the exact same request again, or drop the parameters
                 // and send a GET request
@@ -1024,8 +1070,9 @@ class Client implements Stdlib\DispatchableInterface
                         // Else, assume we have a relative path
                     } else {
                         // Get the current path directory, removing any trailing slashes
-                        $path = $this->getUri()->getPath();
-                        $path = rtrim(substr($path, 0, strrpos($path, '/')), '/');
+                        $path = $this->getUri()->getPath() ?: '/';
+                        $slashPosition = strrpos($path, '/') ?: 0;
+                        $path = rtrim(substr($path, 0, $slashPosition) ?: '', '/');
                         $this->getUri()->setPath($path . '/' . $location);
                     }
                 }
@@ -1120,10 +1167,10 @@ class Client implements Stdlib\DispatchableInterface
     /**
      * Prepare Cookies
      *
-     * @param   string $domain
-     * @param   string $path
+     * @param   null|string $domain
+     * @param   null|string $path
      * @param   bool $secure
-     * @return  Header\Cookie|bool
+     * @return  Header\Cookie
      */
     protected function prepareCookies($domain, $path, $secure)
     {
@@ -1161,6 +1208,11 @@ class Client implements Stdlib\DispatchableInterface
     {
         $headers = [];
 
+        $adapter = $this->getAdapter();
+
+        /** @var Headers|HeaderInterface[] $requestHeaders */
+        $requestHeaders = $this->getRequest()->getHeaders();
+
         // Set the host header
         if ($this->config['httpversion'] == Request::VERSION_11) {
             $host = $uri->getHost();
@@ -1175,7 +1227,7 @@ class Client implements Stdlib\DispatchableInterface
         }
 
         // Set the connection header
-        if (! $this->getRequest()->getHeaders()->has('Connection')) {
+        if (! $requestHeaders->has('Connection')) {
             if (! $this->config['keepalive']) {
                 $headers['Connection'] = 'close';
             }
@@ -1183,7 +1235,7 @@ class Client implements Stdlib\DispatchableInterface
 
         // Set the Accept-encoding header if not set - depending on whether
         // zlib is available or not.
-        if (! $this->getRequest()->getHeaders()->has('Accept-Encoding')) {
+        if (! $requestHeaders->has('Accept-Encoding')) {
             if (empty($this->config['outputstream']) && function_exists('gzinflate')) {
                 $headers['Accept-Encoding'] = 'gzip, deflate';
             } else {
@@ -1192,7 +1244,7 @@ class Client implements Stdlib\DispatchableInterface
         }
 
         // Set the user agent header
-        if (! $this->getRequest()->getHeaders()->has('User-Agent') && isset($this->config['useragent'])) {
+        if (! $requestHeaders->has('User-Agent') && isset($this->config['useragent'])) {
             $headers['User-Agent'] = $this->config['useragent'];
         }
 
@@ -1206,15 +1258,15 @@ class Client implements Stdlib\DispatchableInterface
                     }
                     break;
                 case self::AUTH_DIGEST:
-                    if (! $this->adapter instanceof Client\Adapter\Curl) {
+                    if (! $adapter instanceof Client\Adapter\Curl) {
                         throw new Exception\RuntimeException(sprintf(
                             'The digest authentication is only available for curl adapters (%s)',
                             Curl::class
                         ));
                     }
 
-                    $this->adapter->setCurlOption(CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
-                    $this->adapter->setCurlOption(CURLOPT_USERPWD, $this->auth['user'] . ':' . $this->auth['password']);
+                    $adapter->setCurlOption(CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+                    $adapter->setCurlOption(CURLOPT_USERPWD, $this->auth['user'] . ':' . $this->auth['password']);
             }
         }
 
@@ -1235,7 +1287,6 @@ class Client implements Stdlib\DispatchableInterface
 
         // Merge the headers of the request (if any)
         // here we need right 'http field' and not lowercase letters
-        $requestHeaders = $this->getRequest()->getHeaders();
         foreach ($requestHeaders as $requestHeaderElement) {
             $headers[$requestHeaderElement->getFieldName()] = $requestHeaderElement->getFieldValue();
         }
@@ -1263,14 +1314,17 @@ class Client implements Stdlib\DispatchableInterface
         $body = '';
         $hasFiles = false;
 
-        if (! $this->getRequest()->getHeaders()->has('Content-Type')) {
+        /** @var Headers $headers */
+        $headers = $this->getRequest()->getHeaders();
+
+        if (! $headers->has('Content-Type')) {
             $hasFiles = ! empty($this->getRequest()->getFiles()->toArray());
             // If we have files to upload, force encType to multipart/form-data
             if ($hasFiles) {
                 $this->setEncType(self::ENC_FORMDATA);
             }
         } else {
-            $this->setEncType($this->getHeader('Content-Type'));
+            $this->setEncType($this->getHeader('Content-Type') ?: null);
         }
 
         // If we have POST parameters or files, encode and add them to the body
@@ -1332,14 +1386,16 @@ class Client implements Stdlib\DispatchableInterface
 
         // First try with fileinfo functions
         if (function_exists('finfo_open')) {
+            $fileInfoDb = static::$fileInfoDb;
             if (static::$fileInfoDb === null) {
                 ErrorHandler::start();
-                static::$fileInfoDb = finfo_open(FILEINFO_MIME);
+                $fileInfoDb = finfo_open(FILEINFO_MIME);
                 ErrorHandler::stop();
             }
 
-            if (static::$fileInfoDb) {
-                $type = finfo_file(static::$fileInfoDb, $file);
+            if ($fileInfoDb) {
+                static::$fileInfoDb = $fileInfoDb;
+                $type = finfo_file($fileInfoDb, $file);
             }
         } elseif (function_exists('mime_content_type')) {
             $type = mime_content_type($file);
@@ -1413,7 +1469,7 @@ class Client implements Stdlib\DispatchableInterface
                     $key = $prefix . sprintf('[%s]', $name);
                 }
             } else {
-                $key = $name;
+                $key = (string) $name;
             }
 
             if (is_array($value)) {
@@ -1440,19 +1496,25 @@ class Client implements Stdlib\DispatchableInterface
      */
     protected function doRequest(Http $uri, $method, $secure = false, $headers = [], $body = '')
     {
+        if (null === $uri->getHost()) {
+            throw new InvalidArgumentException('URI does not have an host');
+        }
+
+        $adapter = $this->getAdapter();
+
         // Open the connection, send the request and read the response
-        $this->adapter->connect($uri->getHost(), $uri->getPort(), $secure);
+        $adapter->connect($uri->getHost(), $uri->getPort(), $secure);
 
         if ($this->config['outputstream']) {
-            if ($this->adapter instanceof Client\Adapter\StreamInterface) {
+            if ($adapter instanceof Client\Adapter\StreamInterface) {
                 $this->streamHandle = $this->openTempStream();
-                $this->adapter->setOutputStream($this->streamHandle);
+                $adapter->setOutputStream($this->streamHandle);
             } else {
                 throw new Exception\RuntimeException('Adapter does not support streaming');
             }
         }
         // HTTP connection
-        $this->lastRawRequest = $this->adapter->write(
+        $this->lastRawRequest = $adapter->write(
             $method,
             $uri,
             $this->config['httpversion'],
@@ -1460,7 +1522,7 @@ class Client implements Stdlib\DispatchableInterface
             $body
         );
 
-        return $this->adapter->read();
+        return $adapter->read();
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -743,21 +743,23 @@ class Client implements Stdlib\DispatchableInterface
 
         if (! is_string($this->streamName)) {
             // If name is not given, create temp name
-            /** @var string streamName */
             $this->streamName = tempnam(
                 isset($this->config['streamtmpdir']) ? $this->config['streamtmpdir'] : sys_get_temp_dir(),
                 Client::class
             ) ?: null;
         }
 
+        /** @var string streamName */
+        $streamName = $this->streamName;
+
         ErrorHandler::start();
-        $fp    = fopen($this->streamName, 'w+b');
+        $fp    = fopen($streamName, 'w+b');
         $error = ErrorHandler::stop();
         if (false === $fp) {
             if ($this->adapter instanceof Client\Adapter\AdapterInterface) {
                 $this->adapter->close();
             }
-            throw new Exception\RuntimeException(sprintf('Could not open temp file %s', $this->streamName), 0, $error);
+            throw new Exception\RuntimeException(sprintf('Could not open temp file %s', $streamName), 0, $error);
         }
 
         return $fp;

--- a/src/Client.php
+++ b/src/Client.php
@@ -743,14 +743,11 @@ class Client implements Stdlib\DispatchableInterface
 
         if (! is_string($this->streamName)) {
             // If name is not given, create temp name
+            /** @var string streamName */
             $this->streamName = tempnam(
                 isset($this->config['streamtmpdir']) ? $this->config['streamtmpdir'] : sys_get_temp_dir(),
                 Client::class
             ) ?: null;
-
-            if (null === $this->streamName) {
-                throw new RuntimeException('Unable to create temporary name for stream');
-            }
         }
 
         ErrorHandler::start();

--- a/src/Client/Adapter/Curl.php
+++ b/src/Client/Adapter/Curl.php
@@ -42,7 +42,7 @@ class Curl implements HttpAdapter, StreamInterface
     /**
      * The curl session handle
      *
-     * @var null|resource
+     * @var resource|null
      */
     protected $curl;
 

--- a/src/Client/Adapter/Curl.php
+++ b/src/Client/Adapter/Curl.php
@@ -518,7 +518,7 @@ class Curl implements HttpAdapter, StreamInterface
 
             $again = false;
 
-            if (\is_array($parts) && isset($parts[1]) && preg_match("|^HTTP/1\.[01](.*?)\r\n|mi", $parts[1])) {
+            if (is_array($parts) && isset($parts[1]) && preg_match("|^HTTP/1\.[01](.*?)\r\n|mi", $parts[1])) {
                 $this->response = $parts[1];
                 $again          = true;
             }

--- a/src/Client/Adapter/Exception/UnexpectedValueException.php
+++ b/src/Client/Adapter/Exception/UnexpectedValueException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-http for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-http/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Http\Client\Adapter\Exception;
+
+use Zend\Http\Client\Exception;
+
+class UnexpectedValueException extends Exception\UnexpectedValueException implements
+    ExceptionInterface
+{
+}

--- a/src/Client/Adapter/Proxy.php
+++ b/src/Client/Adapter/Proxy.php
@@ -118,11 +118,11 @@ class Proxy extends Socket
     /**
      * Send request to the proxy server
      *
-     * @param string        $method
-     * @param \Zend\Uri\Uri $uri
-     * @param string        $httpVer
-     * @param array         $headers
-     * @param string        $body
+     * @param string          $method
+     * @param \Zend\Uri\Uri   $uri
+     * @param string          $httpVer
+     * @param array           $headers
+     * @param string|resource $body
      * @throws AdapterException\RuntimeException
      * @return string Request as string
      */
@@ -159,9 +159,19 @@ class Proxy extends Socket
             );
         }
 
+        $host = $uri->getHost();
+        $scheme = $uri->getScheme();
+        $port = $uri->getPort();
+
+        if (null === $host || null === $scheme || null === $port) {
+            throw new AdapterException\InvalidArgumentException(
+                'Invalid Uri object'
+            );
+        }
+
         // if we are proxying HTTPS, preform CONNECT handshake with the proxy
         if ($isSecure && ! $this->negotiated) {
-            $this->connectHandshake($uri->getHost(), $uri->getPort(), $httpVer, $headers);
+            $this->connectHandshake($host, $port, $httpVer, $headers);
             $this->negotiated = true;
         }
 
@@ -226,6 +236,10 @@ class Proxy extends Socket
      */
     protected function connectHandshake($host, $port = 443, $httpVer = '1.1', array &$headers = [])
     {
+        if (null === $this->socket) {
+            throw new AdapterException\RuntimeException('Socket is not initialized');
+        }
+
         $request = 'CONNECT ' . $host . ':' . $port . ' HTTP/' . $httpVer . "\r\n"
             . 'Host: ' . $host . "\r\n";
 

--- a/src/Client/Adapter/Proxy.php
+++ b/src/Client/Adapter/Proxy.php
@@ -159,9 +159,9 @@ class Proxy extends Socket
             );
         }
 
-        $host = $uri->getHost();
+        $host   = $uri->getHost();
         $scheme = $uri->getScheme();
-        $port = $uri->getPort();
+        $port   = $uri->getPort();
 
         if (null === $host || null === $scheme || null === $port) {
             throw new AdapterException\InvalidArgumentException(

--- a/src/Client/Adapter/Socket.php
+++ b/src/Client/Adapter/Socket.php
@@ -288,7 +288,7 @@ class Socket implements HttpAdapter, StreamInterface
             ) ?: null;
             $error = ErrorHandler::stop();
 
-            if (! \is_resource($this->socket)) {
+            if (! is_resource($this->socket)) {
                 $this->close();
                 throw new AdapterException\RuntimeException(
                     sprintf(

--- a/src/Client/Adapter/StreamInterface.php
+++ b/src/Client/Adapter/StreamInterface.php
@@ -19,7 +19,7 @@ interface StreamInterface
      *
      * This function sets output stream where the result will be stored.
      *
-     * @param resource $stream Stream to write the output to
+     * @param null|resource $stream Stream to write the output to
      *
      */
     public function setOutputStream($stream);

--- a/src/Client/Adapter/Test.php
+++ b/src/Client/Adapter/Test.php
@@ -61,7 +61,7 @@ class Test implements AdapterInterface
      * Set the nextRequestWillFail flag
      *
      * @param  bool $flag
-     * @return \Zend\Http\Client\Adapter\Test
+     * @return self
      */
     public function setNextRequestWillFail($flag)
     {

--- a/src/Client/Exception/UnexpectedValueException.php
+++ b/src/Client/Exception/UnexpectedValueException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-http for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-http/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Http\Client\Exception;
+
+use Zend\Http\Exception;
+
+class UnexpectedValueException extends Exception\UnexpectedValueException implements
+    ExceptionInterface
+{
+}

--- a/src/ClientStatic.php
+++ b/src/ClientStatic.php
@@ -7,6 +7,8 @@
 
 namespace Zend\Http;
 
+use Traversable;
+
 /**
  * Http static client
  */
@@ -20,7 +22,7 @@ class ClientStatic
     /**
      * Get the static HTTP client
      *
-     * @param array|Traversable $options
+     * @param array|Traversable|null $options
      * @return Client
      */
     protected static function getStaticClient($options = null)
@@ -56,7 +58,9 @@ class ClientStatic
         }
 
         if (! empty($headers) && is_array($headers)) {
-            $request->getHeaders()->addHeaders($headers);
+            /** @var Headers $requestHeaders */
+            $requestHeaders = $request->getHeaders();
+            $requestHeaders->addHeaders($headers);
         }
 
         if (! empty($body)) {
@@ -98,7 +102,9 @@ class ClientStatic
         }
 
         if (! empty($headers) && is_array($headers)) {
-            $request->getHeaders()->addHeaders($headers);
+            /** @var Headers $requestHeaders */
+            $requestHeaders = $request->getHeaders();
+            $requestHeaders->addHeaders($headers);
         }
 
         if (! empty($body)) {

--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -124,14 +124,14 @@ class Cookies extends Headers
     {
         /** @var Headers $headers */
         $headers = $response->getHeaders();
-        $cookieHdrs = $headers->get('Set-Cookie');
+        $cookieHeaders = $headers->get('Set-Cookie');
 
-        if ($cookieHdrs instanceof ArrayIterator) {
-            foreach ($cookieHdrs as $cookie) {
+        if ($cookieHeaders instanceof ArrayIterator) {
+            foreach ($cookieHeaders as $cookie) {
                 $this->addCookie($cookie);
             }
-        } elseif (is_string($cookieHdrs)) {
-            $this->addCookie($cookieHdrs);
+        } elseif (is_string($cookieHeaders)) {
+            $this->addCookie($cookieHeaders);
         }
     }
 

--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -9,6 +9,7 @@ namespace Zend\Http;
 
 use ArrayIterator;
 use Zend\Http\Exception\InvalidArgumentException;
+use Zend\Http\Exception\LogicException;
 use Zend\Http\Header\SetCookie;
 use Zend\Uri;
 
@@ -264,7 +265,11 @@ class Cookies extends Headers
                 if ($retAs == self::COOKIE_STRING_CONCAT) {
                     $ret .= $this->_flattenCookiesArray($item, $retAs);
                 } else {
-                    $ret = array_merge($ret, $this->_flattenCookiesArray($item, $retAs));
+                    $flatten = $this->_flattenCookiesArray($item, $retAs);
+                    if (!\is_array($ret) || ! \is_array($flatten)) {
+                        throw new LogicException('Flatten cookies is not an array');
+                    }
+                    $ret = array_merge($ret, $flatten);
                 }
             }
             return $ret;

--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -266,7 +266,7 @@ class Cookies extends Headers
                     $ret .= $this->_flattenCookiesArray($item, $retAs);
                 } else {
                     $flatten = $this->_flattenCookiesArray($item, $retAs);
-                    if (!\is_array($ret) || ! \is_array($flatten)) {
+                    if (!is_array($ret) || ! is_array($flatten)) {
                         throw new LogicException('Flatten cookies is not an array');
                     }
                     $ret = array_merge($ret, $flatten);
@@ -328,7 +328,7 @@ class Cookies extends Headers
         foreach ($domains as $dom => $pathsArray) {
             $keys = array_keys($pathsArray);
             foreach ($keys as $cpath) {
-                if (! \is_string($cpath)) {
+                if (! is_string($cpath)) {
                     throw new InvalidArgumentException('Domains is not a valid array');
                 }
                 if (SetCookie::matchCookiePath($cpath, $path)) {

--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -217,7 +217,7 @@ class Cookies extends Headers
         }
 
         // Get correct cookie path
-        $path = $uri->getPath() ?: '';
+        $path = $uri->getPath() ?: '/';
         $lastSlashPos = strrpos($path, '/') ?: 0;
         $path = substr($path, 0, $lastSlashPos);
         if (! $path) {
@@ -315,7 +315,7 @@ class Cookies extends Headers
     /**
      * Return a subset of a domain-matching cookies that also match a specified path
      *
-     * @param array $domains
+     * @param array<string, array<string, mixed>> $domains
      * @param string $path
      * @return array
      */
@@ -326,11 +326,9 @@ class Cookies extends Headers
         $ret = [];
 
         foreach ($domains as $dom => $pathsArray) {
+            /** @var string[] $keys */
             $keys = array_keys($pathsArray);
             foreach ($keys as $cpath) {
-                if (! is_string($cpath)) {
-                    throw new InvalidArgumentException('Domains is not a valid array');
-                }
                 if (SetCookie::matchCookiePath($cpath, $path)) {
                     if (! isset($ret[$dom])) {
                         $ret[$dom] = [];

--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -266,7 +266,7 @@ class Cookies extends Headers
                     $ret .= $this->_flattenCookiesArray($item, $retAs);
                 } else {
                     $flatten = $this->_flattenCookiesArray($item, $retAs);
-                    if (!is_array($ret) || ! is_array($flatten)) {
+                    if (! is_array($ret) || ! is_array($flatten)) {
                         throw new LogicException('Flatten cookies is not an array');
                     }
                     $ret = array_merge($ret, $flatten);

--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -128,10 +128,10 @@ class Cookies extends Headers
 
         if ($cookieHeaders instanceof ArrayIterator) {
             foreach ($cookieHeaders as $cookie) {
-                $this->addCookie($cookie);
+                $this->addCookie($cookie, $refUri);
             }
         } elseif (is_string($cookieHeaders)) {
-            $this->addCookie($cookieHeaders);
+            $this->addCookie($cookieHeaders, $refUri);
         }
     }
 

--- a/src/Exception/LogicException.php
+++ b/src/Exception/LogicException.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-http for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-http/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Http\Exception;
+
+class LogicException extends \LogicException implements
+    ExceptionInterface
+{
+}

--- a/src/Exception/UnexpectedValueException.php
+++ b/src/Exception/UnexpectedValueException.php
@@ -20,7 +20,7 @@ class UnexpectedValueException extends \UnexpectedValueException implements Exce
         return new static(sprintf(
             'Expected %s. %s given',
             $expected,
-            \is_object($actual) ? \get_class($actual) : \gettype($actual)
+            is_object($actual) ? get_class($actual) : gettype($actual)
         ));
     }
 }

--- a/src/Exception/UnexpectedValueException.php
+++ b/src/Exception/UnexpectedValueException.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-http for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-http/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Http\Exception;
+
+class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
+{
+    /**
+     * @param string $expected
+     * @param mixed $actual
+     *
+     * @return UnexpectedValueException
+     */
+    public static function unexpectedType($expected, $actual)
+    {
+        return new static(sprintf(
+            'Expected %s. %s given',
+            $expected,
+            \is_object($actual) ? \get_class($actual) : \gettype($actual)
+        ));
+    }
+}

--- a/src/Header/AbstractAccept.php
+++ b/src/Header/AbstractAccept.php
@@ -7,8 +7,6 @@
 
 namespace Zend\Http\Header;
 
-use stdClass;
-
 /**
  * Abstract Accept Header
  *

--- a/src/Header/AbstractAccept.php
+++ b/src/Header/AbstractAccept.php
@@ -117,7 +117,7 @@ abstract class AbstractAccept implements HeaderInterface
      * Parse the accept params belonging to a media range
      *
      * @param string $fieldValuePart
-     * @return stdClass
+     * @return object
      */
     protected function parseFieldValuePart($fieldValuePart)
     {

--- a/src/Header/AbstractAccept.php
+++ b/src/Header/AbstractAccept.php
@@ -37,7 +37,7 @@ use stdClass;
 abstract class AbstractAccept implements HeaderInterface
 {
     /**
-     * @var stdClass[]
+     * @var object[]
      */
     protected $fieldValueParts = [];
 
@@ -156,7 +156,7 @@ abstract class AbstractAccept implements HeaderInterface
     protected function getParametersFromFieldValuePart($fieldValuePart)
     {
         $params = [];
-        if ((($pos = strpos($fieldValuePart, ';')) !== false)) {
+        if (strpos($fieldValuePart, ';') !== false) {
             preg_match_all('/(?:[^;"]|"(?:[^\\\"]|\\\.)*")+/', $fieldValuePart, $paramsStrings);
 
             if (isset($paramsStrings[0])) {
@@ -167,11 +167,12 @@ abstract class AbstractAccept implements HeaderInterface
             foreach ($paramsStrings as $param) {
                 $explode = explode('=', $param, 2);
 
-                if (count($explode) === 2) {
-                    $value = trim($explode[1]);
-                } else {
-                    $value = null;
+                if (count($explode) === 1) {
+                    $params[trim($explode[0])] = '';
+                    break;
                 }
+
+                $value = trim($explode[1]);
 
                 if (isset($value[0]) && $value[0] == '"' && substr($value, -1) == '"') {
                     $value = substr(substr($value, 1), 0, -1);
@@ -240,7 +241,7 @@ abstract class AbstractAccept implements HeaderInterface
      *
      * @param  string $type
      * @param  int|float $priority
-     * @param  array (optional) $params
+     * @param  array $params (optional)
      * @throws Exception\InvalidArgumentException
      * @return $this
      */
@@ -285,14 +286,14 @@ abstract class AbstractAccept implements HeaderInterface
      */
     protected function hasType($matchAgainst)
     {
-        return (bool) $this->match($matchAgainst);
+        return false !== $this->match($matchAgainst);
     }
 
     /**
      * Match a media string against this header
      *
      * @param array|string $matchAgainst
-     * @return Accept\FieldValuePArt\AcceptFieldValuePart|bool The matched value or false
+     * @return Accept\FieldValuePart\AcceptFieldValuePart|bool The matched value or false
      */
     public function match($matchAgainst)
     {
@@ -330,9 +331,9 @@ abstract class AbstractAccept implements HeaderInterface
     /**
      * Return a match where all parameters in argument #1 match those in argument #2
      *
-     * @param array $match1
-     * @param array $match2
-     * @return bool|array
+     * @param object $match1
+     * @param object $match2
+     * @return bool|object
      */
     protected function matchAcceptParams($match1, $match2)
     {
@@ -376,8 +377,8 @@ abstract class AbstractAccept implements HeaderInterface
     /**
      * Add a key/value combination to the internal queue
      *
-     * @param stdClass $value
-     * @return number
+     * @param object $value
+     * @return void
      */
     protected function addFieldValuePartToQueue($value)
     {

--- a/src/Header/AbstractDate.php
+++ b/src/Header/AbstractDate.php
@@ -95,7 +95,13 @@ abstract class AbstractDate implements HeaderInterface
      */
     public static function fromTimeString($time)
     {
-        return static::fromTimestamp(strtotime($time));
+        $timestamp = strtotime((string) $time);
+
+        if (false === $timestamp) {
+            throw new Exception\InvalidArgumentException(sprintf('Invalid time %s', $time));
+        }
+
+        return static::fromTimestamp($timestamp);
     }
 
     /**
@@ -159,14 +165,16 @@ abstract class AbstractDate implements HeaderInterface
     {
         if (is_string($date)) {
             try {
-                $date = new DateTime($date, new DateTimeZone('GMT'));
+                $dateObj = new DateTime($date, new DateTimeZone('GMT'));
             } catch (\Exception $e) {
                 throw new Exception\InvalidArgumentException(
-                    sprintf('Invalid date passed as string (%s)', (string) $date),
+                    sprintf('Invalid date passed as string (%s)', $date),
                     $e->getCode(),
                     $e
                 );
             }
+
+            $date = $dateObj;
         } elseif (! ($date instanceof DateTime)) {
             throw new Exception\InvalidArgumentException('Date must be an instance of \DateTime or a string');
         }
@@ -195,7 +203,7 @@ abstract class AbstractDate implements HeaderInterface
     public function date()
     {
         if ($this->date === null) {
-            $this->date = new DateTime(null, new DateTimeZone('GMT'));
+            $this->date = new DateTime('now', new DateTimeZone('GMT'));
         }
         return $this->date;
     }
@@ -213,14 +221,16 @@ abstract class AbstractDate implements HeaderInterface
     {
         if (is_string($date)) {
             try {
-                $date = new DateTime($date, new DateTimeZone('GMT'));
+                $dateObj = new DateTime($date, new DateTimeZone('GMT'));
             } catch (\Exception $e) {
                 throw new Exception\InvalidArgumentException(
-                    sprintf('Invalid Date passed as string (%s)', (string) $date),
+                    sprintf('Invalid Date passed as string (%s)', $date),
                     $e->getCode(),
                     $e
                 );
             }
+
+            $date = $dateObj;
         } elseif (! ($date instanceof DateTime)) {
             throw new Exception\InvalidArgumentException('Date must be an instance of \DateTime or a string');
         }

--- a/src/Header/Accept.php
+++ b/src/Header/Accept.php
@@ -51,7 +51,9 @@ class Accept extends AbstractAccept
      */
     public function addMediaType($type, $priority = 1, array $params = [])
     {
-        return $this->addType($type, $priority, $params);
+        $this->addType($type, $priority, $params);
+
+        return $this;
     }
 
     /**

--- a/src/Header/Accept/FieldValuePart/AbstractFieldValuePart.php
+++ b/src/Header/Accept/FieldValuePart/AbstractFieldValuePart.php
@@ -97,15 +97,6 @@ abstract class AbstractFieldValuePart
     }
 
     /**
-     * @param string $key
-     * @return mixed
-     */
-    public function getInternalType($key)
-    {
-        return $this->getInternalValues()->$key;
-    }
-
-    /**
      * @param mixed $key
      * @return mixed
      */

--- a/src/Header/Accept/FieldValuePart/AbstractFieldValuePart.php
+++ b/src/Header/Accept/FieldValuePart/AbstractFieldValuePart.php
@@ -69,7 +69,7 @@ abstract class AbstractFieldValuePart
      */
     public function getTypeString()
     {
-        return $this->getInternalValues()->typeString;
+        return $this->typeString;
     }
 
     /**
@@ -77,7 +77,7 @@ abstract class AbstractFieldValuePart
      */
     public function getPriority()
     {
-        return (float) $this->getInternalValues()->priority;
+        return (float) $this->priority;
     }
 
     /**
@@ -85,7 +85,7 @@ abstract class AbstractFieldValuePart
      */
     public function getParams()
     {
-        return (object) $this->getInternalValues()->params;
+        return (object) $this->params;
     }
 
     /**
@@ -93,7 +93,16 @@ abstract class AbstractFieldValuePart
      */
     public function getRaw()
     {
-        return $this->getInternalValues()->raw;
+        return $this->raw;
+    }
+
+    /**
+     * @param string $key
+     * @return mixed
+     */
+    public function getInternalType($key)
+    {
+        return $this->getInternalValues()->$key;
     }
 
     /**

--- a/src/Header/Accept/FieldValuePart/AbstractFieldValuePart.php
+++ b/src/Header/Accept/FieldValuePart/AbstractFieldValuePart.php
@@ -81,7 +81,7 @@ abstract class AbstractFieldValuePart
     }
 
     /**
-     * @return \stdClass $params
+     * @return object $params
      */
     public function getParams()
     {

--- a/src/Header/Accept/FieldValuePart/AcceptFieldValuePart.php
+++ b/src/Header/Accept/FieldValuePart/AcceptFieldValuePart.php
@@ -19,7 +19,7 @@ class AcceptFieldValuePart extends AbstractFieldValuePart
      */
     public function getSubtype()
     {
-        return $this->getInternalValues()->subtype;
+        return $this->subtype;
     }
 
     /**
@@ -27,7 +27,7 @@ class AcceptFieldValuePart extends AbstractFieldValuePart
      */
     public function getSubtypeRaw()
     {
-        return $this->getInternalValues()->subtypeRaw;
+        return $this->subtypeRaw;
     }
 
     /**
@@ -35,6 +35,6 @@ class AcceptFieldValuePart extends AbstractFieldValuePart
      */
     public function getFormat()
     {
-        return $this->getInternalValues()->format;
+        return $this->format;
     }
 }

--- a/src/Header/Accept/FieldValuePart/CharsetFieldValuePart.php
+++ b/src/Header/Accept/FieldValuePart/CharsetFieldValuePart.php
@@ -19,6 +19,6 @@ class CharsetFieldValuePart extends AbstractFieldValuePart
      */
     public function getCharset()
     {
-        return $this->getInternalValues()->type;
+        return $this->type;
     }
 }

--- a/src/Header/Accept/FieldValuePart/EncodingFieldValuePart.php
+++ b/src/Header/Accept/FieldValuePart/EncodingFieldValuePart.php
@@ -19,6 +19,6 @@ class EncodingFieldValuePart extends AbstractFieldValuePart
      */
     public function getEncoding()
     {
-        return $this->getInternalValues()->type;
+        return $this->type;
     }
 }

--- a/src/Header/Accept/FieldValuePart/LanguageFieldValuePart.php
+++ b/src/Header/Accept/FieldValuePart/LanguageFieldValuePart.php
@@ -16,16 +16,16 @@ class LanguageFieldValuePart extends AbstractFieldValuePart
 {
     public function getLanguage()
     {
-        return $this->getInternalValues()->typeString;
+        return $this->typeString;
     }
 
     public function getPrimaryTag()
     {
-        return $this->getInternalValues()->type;
+        return $this->type;
     }
 
     public function getSubTag()
     {
-        return $this->getInternalValues()->subtype;
+        return $this->subtype;
     }
 }

--- a/src/Header/AcceptCharset.php
+++ b/src/Header/AcceptCharset.php
@@ -47,7 +47,9 @@ class AcceptCharset extends AbstractAccept
      */
     public function addCharset($type, $priority = 1)
     {
-        return $this->addType($type, $priority);
+        $this->addType($type, $priority);
+
+        return $this;
     }
 
     /**

--- a/src/Header/AcceptEncoding.php
+++ b/src/Header/AcceptEncoding.php
@@ -47,7 +47,9 @@ class AcceptEncoding extends AbstractAccept
      */
     public function addEncoding($type, $priority = 1)
     {
-        return $this->addType($type, $priority);
+        $this->addType($type, $priority);
+
+        return $this;
     }
 
     /**

--- a/src/Header/AcceptLanguage.php
+++ b/src/Header/AcceptLanguage.php
@@ -47,7 +47,9 @@ class AcceptLanguage extends AbstractAccept
      */
     public function addLanguage($type, $priority = 1)
     {
-        return $this->addType($type, $priority);
+        $this->addType($type, $priority);
+
+        return $this;
     }
 
     /**

--- a/src/Header/CacheControl.php
+++ b/src/Header/CacheControl.php
@@ -186,14 +186,13 @@ class CacheControl implements HeaderInterface
         switch (static::match(['[a-zA-Z][a-zA-Z_-]*'], $value, $lastMatch)) {
             case 0:
                 $directive = $lastMatch;
-                goto state_value;
+                break;
                 // intentional fall-through
 
             default:
                 throw new Exception\InvalidArgumentException('expected DIRECTIVE');
         }
 
-        state_value:
         switch (static::match(['="[^"]*"', '=[^",\s;]*'], $value, $lastMatch)) {
             case 0:
                 $directives[$directive] = substr($lastMatch, 2, -1);

--- a/src/Header/ContentSecurityPolicy.php
+++ b/src/Header/ContentSecurityPolicy.php
@@ -124,7 +124,7 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
             return $this;
         }
 
-        array_walk($sources, [__NAMESPACE__ . '\HeaderValue', 'assertValid']);
+        array_walk($sources, [HeaderValue::class, 'assertValid']);
         $this->directives[$name] = implode(' ', $sources);
 
         return $this;

--- a/src/Header/ContentType.php
+++ b/src/Header/ContentType.php
@@ -7,8 +7,6 @@
 
 namespace Zend\Http\Header;
 
-use stdClass;
-
 /**
  * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17
@@ -277,7 +275,7 @@ class ContentType implements HeaderInterface
      * - format
      *
      * @param  null|string $string
-     * @return stdClass
+     * @return object
      */
     protected function getMediaTypeObjectFromString($string)
     {
@@ -320,8 +318,8 @@ class ContentType implements HeaderInterface
     /**
      * Validate a subtype
      *
-     * @param  stdClass $right
-     * @param  stdClass $left
+     * @param  object $right
+     * @param  object $left
      * @return bool
      */
     protected function validateSubtype($right, $left)
@@ -360,8 +358,8 @@ class ContentType implements HeaderInterface
      *
      * Validate that the right side format matches what the left side defines.
      *
-     * @param  stdClass $right
-     * @param  stdClass $left
+     * @param  object $right
+     * @param  object $left
      * @return bool
      */
     protected function validateFormat($right, $left)

--- a/src/Header/ContentType.php
+++ b/src/Header/ContentType.php
@@ -16,7 +16,7 @@ use stdClass;
 class ContentType implements HeaderInterface
 {
     /**
-     * @var string
+     * @var null|string
      */
     protected $mediaType;
 
@@ -26,7 +26,7 @@ class ContentType implements HeaderInterface
     protected $parameters = [];
 
     /**
-     * @var string
+     * @var null|string
      */
     protected $value;
 
@@ -49,6 +49,7 @@ class ContentType implements HeaderInterface
         }
 
         $parts     = explode(';', $value);
+        /** @var string $mediaType */
         $mediaType = array_shift($parts);
         $header    = new static($value, trim($mediaType));
 
@@ -168,7 +169,7 @@ class ContentType implements HeaderInterface
     /**
      * Get the media type
      *
-     * @return string
+     * @return null|string
      */
     public function getMediaType()
     {
@@ -238,7 +239,7 @@ class ContentType implements HeaderInterface
     {
         $mediaType = $this->getMediaType();
         if (empty($this->parameters)) {
-            return $mediaType;
+            return $mediaType ?: '';
         }
 
         $parameters = [];
@@ -275,7 +276,7 @@ class ContentType implements HeaderInterface
      * - subtype
      * - format
      *
-     * @param  string $string
+     * @param  null|string $string
      * @return stdClass
      */
     protected function getMediaTypeObjectFromString($string)
@@ -287,15 +288,18 @@ class ContentType implements HeaderInterface
             ));
         }
 
+        /** @var string[] $parts */
         $parts = explode('/', $string, 2);
-        if (1 == count($parts)) {
+        if (1 === count($parts)) {
             throw new Exception\DomainException(sprintf(
                 'Invalid mediatype "%s" provided',
                 $string
             ));
         }
 
+        /** @var string $type */
         $type    = array_shift($parts);
+        /** @var string $subtype */
         $subtype = array_shift($parts);
         $format  = $subtype;
         if (false !== strpos($subtype, '+')) {
@@ -356,17 +360,17 @@ class ContentType implements HeaderInterface
      *
      * Validate that the right side format matches what the left side defines.
      *
-     * @param  string $right
-     * @param  string $left
+     * @param  stdClass $right
+     * @param  stdClass $left
      * @return bool
      */
     protected function validateFormat($right, $left)
     {
         if ($right->format && $left->format) {
-            if ($right->format == '*') {
+            if ($right->format === '*') {
                 return true;
             }
-            if ($right->format == $left->format) {
+            if ($right->format === $left->format) {
                 return true;
             }
             return false;

--- a/src/Header/Cookie.php
+++ b/src/Header/Cookie.php
@@ -29,6 +29,13 @@ class Cookie extends ArrayObject implements HeaderInterface
                 ));
             }
 
+            if (null === $setCookie->getName()) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    '%s requires cookies with name',
+                    __METHOD__
+                ));
+            }
+
             if (array_key_exists($setCookie->getName(), $nvPairs)) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     'Two cookies with the same name were provided to %s',
@@ -55,10 +62,14 @@ class Cookie extends ArrayObject implements HeaderInterface
 
         $nvPairs = preg_split('#;\s*#', $value);
 
+        if (false === $nvPairs) {
+            throw new Exception\RuntimeException('Malformed Cookie header found');
+        }
+
         $arrayInfo = [];
         foreach ($nvPairs as $nvPair) {
             $parts = explode('=', $nvPair, 2);
-            if (count($parts) != 2) {
+            if (count($parts) !== 2) {
                 throw new Exception\RuntimeException('Malformed Cookie header found');
             }
             list($name, $value) = $parts;
@@ -78,7 +89,7 @@ class Cookie extends ArrayObject implements HeaderInterface
     /**
      * @param bool $encodeValue
      *
-     * @return $this
+     * @return self
      */
     public function setEncodeValue($encodeValue)
     {
@@ -104,7 +115,7 @@ class Cookie extends ArrayObject implements HeaderInterface
         $nvPairs = [];
 
         foreach ($this->flattenCookies($this) as $name => $value) {
-            $nvPairs[] = $name . '=' . (($this->encodeValue) ? urlencode($value) : $value);
+            $nvPairs[] = $name . '=' . ($this->encodeValue ? urlencode($value) : $value);
         }
 
         return implode('; ', $nvPairs);

--- a/src/Header/Cookie.php
+++ b/src/Header/Cookie.php
@@ -86,7 +86,7 @@ class Cookie extends ArrayObject implements HeaderInterface
     /**
      * @param bool $encodeValue
      *
-     * @return self
+     * @return $this
      */
     public function setEncodeValue($encodeValue)
     {

--- a/src/Header/Cookie.php
+++ b/src/Header/Cookie.php
@@ -60,11 +60,8 @@ class Cookie extends ArrayObject implements HeaderInterface
             throw new Exception\InvalidArgumentException('Invalid header line for Server string: "' . $name . '"');
         }
 
+        /** @var string[] $nvPairs */
         $nvPairs = preg_split('#;\s*#', $value);
-
-        if (false === $nvPairs) {
-            throw new Exception\RuntimeException('Malformed Cookie header found');
-        }
 
         $arrayInfo = [];
         foreach ($nvPairs as $nvPair) {

--- a/src/Header/GenericMultiHeader.php
+++ b/src/Header/GenericMultiHeader.php
@@ -9,6 +9,10 @@ namespace Zend\Http\Header;
 
 class GenericMultiHeader extends GenericHeader implements MultipleHeaderInterface
 {
+    /**
+     * @param string $headerLine
+     * @return GenericMultiHeader|GenericMultiHeader[]
+     */
     public static function fromString($headerLine)
     {
         list($fieldName, $fieldValue) = GenericHeader::splitHeaderLine($headerLine);

--- a/src/Header/HeaderValue.php
+++ b/src/Header/HeaderValue.php
@@ -26,7 +26,7 @@ final class HeaderValue
      * between visible characters.
      *
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
-     * @param string $value
+     * @param null|string $value
      * @return string
      */
     public static function filter($value)
@@ -63,7 +63,7 @@ final class HeaderValue
      * between visible characters.
      *
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
-     * @param string $value
+     * @param null|string $value
      * @return bool
      */
     public static function isValid($value)
@@ -92,7 +92,7 @@ final class HeaderValue
     /**
      * Assert a header value is valid.
      *
-     * @param string $value
+     * @param null|string $value
      * @throws Exception\RuntimeException for invalid values
      * @return void
      */

--- a/src/Header/RetryAfter.php
+++ b/src/Header/RetryAfter.php
@@ -43,7 +43,7 @@ class RetryAfter extends AbstractDate
         }
 
         if (is_numeric($date)) {
-            $dateHeader->setDeltaSeconds($date);
+            $dateHeader->setDeltaSeconds((int) $date);
         } else {
             $dateHeader->setDate($date);
         }

--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -258,7 +258,7 @@ class SetCookie implements MultipleHeaderInterface
              ->setExpires($expires)
              ->setPath($path)
              ->setSecure($secure)
-             ->setHttponly($httponly)
+             ->setHttpOnly($httponly)
              ->setSameSite($sameSite);
     }
 
@@ -334,7 +334,7 @@ class SetCookie implements MultipleHeaderInterface
             $fieldValue .= '; Secure';
         }
 
-        if ($this->isHttpOnly()) {
+        if ($this->isHttponly()) {
             $fieldValue .= '; HttpOnly';
         }
 
@@ -347,7 +347,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  null|string|null $name
+     * @param  string|null $name
      * @return $this
      * @throws Exception\InvalidArgumentException
      */
@@ -359,7 +359,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return null|string|null
+     * @return string|null
      */
     public function getName()
     {
@@ -367,7 +367,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  null|string $value
+     * @param  string|null $value
      * @return $this
      */
     public function setValue($value)
@@ -377,7 +377,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return null|string|null
+     * @return string|null
      */
     public function getValue()
     {
@@ -385,7 +385,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  null|int|null $version
+     * @param  int|null $version
      * @return $this
      * @throws Exception\InvalidArgumentException
      */
@@ -399,7 +399,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return null|int|null
+     * @return int|null
      */
     public function getVersion()
     {
@@ -407,7 +407,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  null|int $maxAge
+     * @param  int|null $maxAge
      * @return $this
      */
     public function setMaxAge($maxAge)
@@ -421,7 +421,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return null|int|null
+     * @return int|null
      */
     public function getMaxAge()
     {
@@ -429,7 +429,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  null|int|string|DateTime|null $expires
+     * @param  int|string|DateTime|null $expires
      * @return $this
      * @throws Exception\InvalidArgumentException
      */
@@ -469,7 +469,7 @@ class SetCookie implements MultipleHeaderInterface
 
     /**
      * @param  bool $inSeconds
-     * @return null|int|string|null
+     * @return int|string|null
      */
     public function getExpires($inSeconds = false)
     {
@@ -483,7 +483,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  null|string $domain
+     * @param  string|null $domain
      * @return $this
      */
     public function setDomain($domain)
@@ -494,7 +494,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return null|string|null
+     * @return string|null
      */
     public function getDomain()
     {
@@ -502,7 +502,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  null|string $path
+     * @param  string|null $path
      * @return $this
      */
     public function setPath($path)
@@ -513,7 +513,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return null|string|null
+     * @return string|null
      */
     public function getPath()
     {
@@ -521,7 +521,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  null|bool $secure
+     * @param  bool|null $secure
      * @return $this
      */
     public function setSecure($secure)
@@ -546,7 +546,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return null|bool|null
+     * @return bool|null
      */
     public function isSecure()
     {
@@ -554,7 +554,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  null|bool $httponly
+     * @param  bool|null $httponly
      * @return $this
      */
     public function setHttponly($httponly)
@@ -567,7 +567,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return null|bool|null
+     * @return bool|null
      */
     public function isHttpOnly()
     {
@@ -579,7 +579,7 @@ class SetCookie implements MultipleHeaderInterface
      *
      * Always returns false if the cookie is a session cookie (has no expiry time)
      *
-     * @param null|int|null $now Timestamp to consider as "now"
+     * @param int|null $now Timestamp to consider as "now"
      * @return bool
      */
     public function isExpired($now = null)

--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -125,7 +125,7 @@ class SetCookie implements MultipleHeaderInterface
     /**
      * @static
      * @throws Exception\InvalidArgumentException
-     * @param  $headerLine
+     * @param  string $headerLine
      * @param  bool $bypassHeaderFieldName
      * @return array|SetCookie
      */
@@ -138,6 +138,7 @@ class SetCookie implements MultipleHeaderInterface
             $setCookieProcessor = function ($headerLine) use ($setCookieClass) {
                 /** @var SetCookie $header */
                 $header = new $setCookieClass();
+                /** @var string[] $keyValuePairs */
                 $keyValuePairs = preg_split('#;\s*#', $headerLine);
 
                 foreach ($keyValuePairs as $keyValue) {
@@ -207,17 +208,18 @@ class SetCookie implements MultipleHeaderInterface
             throw new Exception\InvalidArgumentException('Invalid header line for Set-Cookie string: "' . $name . '"');
         }
 
+        /** @var string[] $multipleHeaders */
         $multipleHeaders = preg_split('#(?<!Sun|Mon|Tue|Wed|Thu|Fri|Sat),\s*#', $value);
 
         if (count($multipleHeaders) <= 1) {
             return $setCookieProcessor(array_pop($multipleHeaders));
-        } else {
-            $headers = [];
-            foreach ($multipleHeaders as $headerLine) {
-                $headers[] = $setCookieProcessor($headerLine);
-            }
-            return $headers;
         }
+
+        $headers = [];
+        foreach ($multipleHeaders as $headerLine) {
+            $headers[] = $setCookieProcessor($headerLine);
+        }
+        return $headers;
     }
 
     /**
@@ -248,8 +250,6 @@ class SetCookie implements MultipleHeaderInterface
         $version = null,
         $sameSite = null
     ) {
-        $this->type = 'Cookie';
-
         $this->setName($name)
              ->setValue($value)
              ->setVersion($version)
@@ -258,7 +258,7 @@ class SetCookie implements MultipleHeaderInterface
              ->setExpires($expires)
              ->setPath($path)
              ->setSecure($secure)
-             ->setHttpOnly($httponly)
+             ->setHttponly($httponly)
              ->setSameSite($sameSite);
     }
 
@@ -296,7 +296,9 @@ class SetCookie implements MultipleHeaderInterface
             return '';
         }
 
-        $value = $this->encodeValue ? urlencode($this->getValue()) : $this->getValue();
+        $value = $this->getValue() ?: '';
+        $value = $this->encodeValue ? urlencode($value) : $value;
+
         if ($this->hasQuoteFieldValue()) {
             $value = '"' . $value . '"';
         }
@@ -332,7 +334,7 @@ class SetCookie implements MultipleHeaderInterface
             $fieldValue .= '; Secure';
         }
 
-        if ($this->isHttponly()) {
+        if ($this->isHttpOnly()) {
             $fieldValue .= '; HttpOnly';
         }
 
@@ -345,7 +347,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  string|null $name
+     * @param  null|string|null $name
      * @return $this
      * @throws Exception\InvalidArgumentException
      */
@@ -357,7 +359,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return string|null
+     * @return null|string|null
      */
     public function getName()
     {
@@ -365,7 +367,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  string|null $value
+     * @param  null|string|null $value
      * @return $this
      */
     public function setValue($value)
@@ -375,7 +377,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return string|null
+     * @return null|string|null
      */
     public function getValue()
     {
@@ -383,7 +385,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  int|null $version
+     * @param  null|int|null $version
      * @return $this
      * @throws Exception\InvalidArgumentException
      */
@@ -397,7 +399,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return int|null
+     * @return null|int|null
      */
     public function getVersion()
     {
@@ -405,7 +407,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  int $maxAge
+     * @param  null|int $maxAge
      * @return $this
      */
     public function setMaxAge($maxAge)
@@ -419,7 +421,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return int|null
+     * @return null|int|null
      */
     public function getMaxAge()
     {
@@ -427,7 +429,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  int|string|DateTime|null $expires
+     * @param  null|int|string|DateTime|null $expires
      * @return $this
      * @throws Exception\InvalidArgumentException
      */
@@ -467,7 +469,7 @@ class SetCookie implements MultipleHeaderInterface
 
     /**
      * @param  bool $inSeconds
-     * @return int|string|null
+     * @return null|int|string|null
      */
     public function getExpires($inSeconds = false)
     {
@@ -481,7 +483,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  string|null $domain
+     * @param  null|string|null $domain
      * @return $this
      */
     public function setDomain($domain)
@@ -492,7 +494,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return string|null
+     * @return null|string|null
      */
     public function getDomain()
     {
@@ -500,7 +502,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  string|null $path
+     * @param  null|string|null $path
      * @return $this
      */
     public function setPath($path)
@@ -511,7 +513,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return string|null
+     * @return null|string|null
      */
     public function getPath()
     {
@@ -519,7 +521,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  bool|null $secure
+     * @param  null|bool|null $secure
      * @return $this
      */
     public function setSecure($secure)
@@ -544,7 +546,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return bool|null
+     * @return null|bool|null
      */
     public function isSecure()
     {
@@ -552,7 +554,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  bool|null $httponly
+     * @param  null|bool|null $httponly
      * @return $this
      */
     public function setHttponly($httponly)
@@ -565,9 +567,9 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @return bool|null
+     * @return null|bool|null
      */
-    public function isHttponly()
+    public function isHttpOnly()
     {
         return $this->httponly;
     }
@@ -577,7 +579,7 @@ class SetCookie implements MultipleHeaderInterface
      *
      * Always returns false if the cookie is a session cookie (has no expiry time)
      *
-     * @param int|null $now Timestamp to consider as "now"
+     * @param null|int|null $now Timestamp to consider as "now"
      * @return bool
      */
     public function isExpired($now = null)
@@ -646,11 +648,13 @@ class SetCookie implements MultipleHeaderInterface
      */
     public function isValidForRequest($requestDomain, $path, $isSecure = false)
     {
-        if ($this->getDomain() && (strrpos($requestDomain, $this->getDomain()) === false)) {
+        $cookieDomain = $this->getDomain();
+        if ($cookieDomain && (strrpos($requestDomain, $cookieDomain) === false)) {
             return false;
         }
 
-        if ($this->getPath() && (strpos($path, $this->getPath()) !== 0)) {
+        $cookiePath = $this->getPath();
+        if ($cookiePath && (strpos($path, $cookiePath) !== 0)) {
             return false;
         }
 
@@ -677,12 +681,12 @@ class SetCookie implements MultipleHeaderInterface
         }
 
         // Make sure we have a valid Zend_Uri_Http object
-        if (! ($uri->isValid() && ($uri->getScheme() == 'http' || $uri->getScheme() == 'https'))) {
+        if (! ($uri->isValid() && ($uri->getScheme() === 'http' || $uri->getScheme() === 'https'))) {
             throw new Exception\InvalidArgumentException('Passed URI is not a valid HTTP or HTTPS URI');
         }
 
         // Check that the cookie is secure (if required) and not expired
-        if ($this->secure && $uri->getScheme() != 'https') {
+        if ($this->secure && $uri->getScheme() !== 'https') {
             return false;
         }
         if ($this->isExpired($now)) {
@@ -693,11 +697,15 @@ class SetCookie implements MultipleHeaderInterface
         }
 
         // Check if the domain matches
-        if (! self::matchCookieDomain($this->getDomain(), $uri->getHost())) {
+        if (! self::matchCookieDomain($this->getDomain() ?: '', $uri->getHost() ?: '')) {
             return false;
         }
 
         // Check that path matches using prefix match
+        if (null === $this->getPath() || null === $uri->getPath()) {
+            return false;
+        }
+
         if (! self::matchCookiePath($this->getPath(), $uri->getPath())) {
             return false;
         }

--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -367,7 +367,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  null|string|null $value
+     * @param  null|string $value
      * @return $this
      */
     public function setValue($value)
@@ -483,7 +483,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  null|string|null $domain
+     * @param  null|string $domain
      * @return $this
      */
     public function setDomain($domain)
@@ -502,7 +502,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  null|string|null $path
+     * @param  null|string $path
      * @return $this
      */
     public function setPath($path)
@@ -521,7 +521,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  null|bool|null $secure
+     * @param  null|bool $secure
      * @return $this
      */
     public function setSecure($secure)
@@ -554,7 +554,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * @param  null|bool|null $httponly
+     * @param  null|bool $httponly
      * @return $this
      */
     public function setHttponly($httponly)

--- a/src/PhpEnvironment/RemoteAddress.php
+++ b/src/PhpEnvironment/RemoteAddress.php
@@ -94,6 +94,7 @@ class RemoteAddress
      */
     public function getIpAddress()
     {
+        /** @var string|false $ip */
         $ip = $this->getIpAddressFromProxy();
         if ($ip) {
             return $ip;
@@ -111,7 +112,7 @@ class RemoteAddress
      * Attempt to get the IP address for a proxied client
      *
      * @see http://tools.ietf.org/html/draft-ietf-appsawg-http-forwarded-10#section-5.2
-     * @return false|string
+     * @return bool|string
      */
     protected function getIpAddressFromProxy()
     {
@@ -143,6 +144,7 @@ class RemoteAddress
         // not know if it is a proxy server, or a client. As such, we treat it
         // as the originating IP.
         // @see http://en.wikipedia.org/wiki/X-Forwarded-For
+        /** @var string $ip */
         $ip = array_pop($ips);
         return $ip;
     }

--- a/src/PhpEnvironment/RemoteAddress.php
+++ b/src/PhpEnvironment/RemoteAddress.php
@@ -132,6 +132,7 @@ class RemoteAddress
         // trim, so we can compare against trusted proxies properly
         $ips = array_map('trim', $ips);
         // remove trusted proxy IPs
+        /** @var string[] $ips */
         $ips = array_diff($ips, $this->trustedProxies);
 
         // Any left?
@@ -144,7 +145,6 @@ class RemoteAddress
         // not know if it is a proxy server, or a client. As such, we treat it
         // as the originating IP.
         // @see http://en.wikipedia.org/wiki/X-Forwarded-For
-        /** @var string $ip */
         $ip = array_pop($ips);
         return $ip;
     }

--- a/src/PhpEnvironment/Request.php
+++ b/src/PhpEnvironment/Request.php
@@ -210,7 +210,7 @@ class Request extends HttpRequest
         // This seems to be the only way to get the Authorization header on Apache
         if (function_exists('apache_request_headers')) {
             $apacheRequestHeaders = apache_request_headers();
-            if (! isset($this->serverParams['HTTP_AUTHORIZATION'])) {
+            if (false !== $apacheRequestHeaders && ! isset($this->serverParams['HTTP_AUTHORIZATION'])) {
                 if (isset($apacheRequestHeaders['Authorization'])) {
                     $this->serverParams->set('HTTP_AUTHORIZATION', $apacheRequestHeaders['Authorization']);
                 } elseif (isset($apacheRequestHeaders['authorization'])) {

--- a/src/PhpEnvironment/Request.php
+++ b/src/PhpEnvironment/Request.php
@@ -7,7 +7,6 @@
 
 namespace Zend\Http\PhpEnvironment;
 
-use Zend\Http\Exception\RuntimeException;
 use Zend\Http\Header\Cookie;
 use Zend\Http\Header\HeaderInterface;
 use Zend\Http\Headers;

--- a/src/PhpEnvironment/Response.php
+++ b/src/PhpEnvironment/Response.php
@@ -96,7 +96,6 @@ class Response extends HttpResponse
             header($header->toString());
         }
 
-        $this->headersSent = true;
         return $this;
     }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -113,6 +113,13 @@ class Request extends AbstractMessage implements RequestInterface
         $request->setUri($matches['uri']);
 
         $parsedUri = parse_url($matches['uri']);
+
+        if (false === $parsedUri) {
+            throw new Exception\InvalidArgumentException(
+                'A valid request line was not found in the provided string'
+            );
+        }
+
         if (array_key_exists('query', $parsedUri)) {
             $parsedQuery = [];
             parse_str($parsedUri['query'], $parsedQuery);
@@ -216,6 +223,13 @@ class Request extends AbstractMessage implements RequestInterface
                 'URI must be an instance of Zend\Uri\Http or a string'
             );
         }
+
+        $path = $uri->getPath();
+
+        if (empty($path)) {
+            $uri->setPath('/');
+        }
+
         $this->uri = $uri;
 
         return $this;

--- a/src/Request.php
+++ b/src/Request.php
@@ -7,6 +7,7 @@
 
 namespace Zend\Http;
 
+use Zend\Http\Header\HeaderInterface;
 use Zend\Stdlib\Parameters;
 use Zend\Stdlib\ParametersInterface;
 use Zend\Stdlib\RequestInterface;
@@ -100,6 +101,7 @@ class Request extends AbstractMessage implements RequestInterface
             );
 
         $regex     = '#^(?P<method>' . $methods . ')\s(?P<uri>[^ ]*)(?:\sHTTP\/(?P<version>\d+\.\d+)){0,1}#';
+        /** @var string $firstLine */
         $firstLine = array_shift($lines);
         if (! preg_match($regex, $firstLine, $matches)) {
             throw new Exception\InvalidArgumentException(
@@ -128,6 +130,7 @@ class Request extends AbstractMessage implements RequestInterface
         $isHeader = true;
         $headers = $rawBody = [];
         while ($lines) {
+            /** @var string $nextLine */
             $nextLine = array_shift($lines);
             if ($nextLine == '') {
                 $isHeader = false;
@@ -318,7 +321,12 @@ class Request extends AbstractMessage implements RequestInterface
      */
     public function getCookie()
     {
-        return $this->getHeaders()->get('Cookie');
+        /** @var Headers $headers */
+        $headers = $this->getHeaders();
+        /** @var false|Header\Cookie $header */
+        $header = $headers->get('Cookie');
+
+        return $header;
     }
 
     /**
@@ -366,7 +374,7 @@ class Request extends AbstractMessage implements RequestInterface
     {
         if ($this->headers === null || is_string($this->headers)) {
             // this is only here for fromString lazy loading
-            $this->headers = (is_string($this->headers)) ? Headers::fromString($this->headers) : new Headers();
+            $this->headers = is_string($this->headers) ? Headers::fromString($this->headers) : new Headers();
         }
 
         if ($name === null) {
@@ -390,7 +398,10 @@ class Request extends AbstractMessage implements RequestInterface
      */
     public function getHeader($name, $default = false)
     {
-        return $this->getHeaders($name, $default);
+        /** @var false|HeaderInterface $header */
+        $header = $this->getHeaders($name, $default);
+
+        return $header;
     }
 
     /**
@@ -502,8 +513,11 @@ class Request extends AbstractMessage implements RequestInterface
      */
     public function isXmlHttpRequest()
     {
-        $header = $this->getHeaders()->get('X_REQUESTED_WITH');
-        return false !== $header && $header->getFieldValue() == 'XMLHttpRequest';
+        /** @var Headers $headers */
+        $headers = $this->getHeaders();
+        /** @var false|HeaderInterface $header */
+        $header = $headers->get('X_REQUESTED_WITH');
+        return false !== $header && $header->getFieldValue() === 'XMLHttpRequest';
     }
 
     /**
@@ -513,7 +527,10 @@ class Request extends AbstractMessage implements RequestInterface
      */
     public function isFlashRequest()
     {
-        $header = $this->getHeaders()->get('USER_AGENT');
+        /** @var Headers $headers */
+        $headers = $this->getHeaders();
+        /** @var false|HeaderInterface $header */
+        $header = $headers->get('USER_AGENT');
         return false !== $header && stristr($header->getFieldValue(), ' flash');
     }
 
@@ -532,8 +549,10 @@ class Request extends AbstractMessage implements RequestInterface
      */
     public function toString()
     {
+        /** @var Headers $headers */
+        $headers = $this->getHeaders();
         $str = $this->renderRequestLine() . "\r\n";
-        $str .= $this->getHeaders()->toString();
+        $str .= $headers->toString();
         $str .= "\r\n";
         $str .= $this->getContent();
         return $str;

--- a/src/Response.php
+++ b/src/Response.php
@@ -589,10 +589,10 @@ class Response extends AbstractMessage implements ResponseInterface
             );
         }
 
-        $contentLengthHeader = $body === ''
-            || ($this->getHeaders()->get('content-length');
-            if ($contentLengthHeader instanceof Header\ContentLength
-            && (int) $contentLengthHeader->getFieldValue() === 0)
+        $contentLengthHeader = $this->getHeaders()->get('content-length');
+        if ($body === ''
+            || ($contentLengthHeader instanceof Header\ContentLength
+                && (int) $contentLengthHeader->getFieldValue() === 0)
         ) {
             return '';
         }

--- a/src/Response.php
+++ b/src/Response.php
@@ -7,9 +7,7 @@
 
 namespace Zend\Http;
 
-use ArrayIterator;
-use Zend\Http\Exception\RuntimeException;
-use Zend\Http\Exception\UnexpectedValueException;
+use Zend\Http\Exception\InvalidArgumentException;
 use Zend\Http\Header\HeaderInterface;
 use Zend\Stdlib\ErrorHandler;
 use Zend\Stdlib\ResponseInterface;
@@ -213,7 +211,7 @@ class Response extends AbstractMessage implements ResponseInterface
             $next = array_shift($lines); // take next line
             $next = empty($next) ? array_shift($lines) : $next; // take next or skip if empty
             if (null === $next) {
-                throw new RuntimeException('Invalid response content');
+                throw new Exception\InvalidArgumentException('Invalid response content');
             }
             $response->parseStatusLine($next);
         }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -645,6 +645,19 @@ class ClientTest extends TestCase
         $client->setUri('/example');
     }
 
+    public function testRelativeUriIsNotAllowedSendingRequest()
+    {
+        $this->expectException(HttpException\InvalidArgumentException::class);
+
+        $client = new Client();
+        $uri = new Http();
+        $request = new Request();
+        $request->setUri($uri);
+        $request->setMethod(Request::METHOD_GET);
+        $client->setAdapter(Test::class);
+        $client->send($request);
+    }
+
     public function portChangeDataProvider()
     {
         return [

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -881,32 +881,6 @@ class ClientTest extends TestCase
         $this->assertNotContains("\r\nCookie: foo=far; bar=far\r\n", $lastRawRequest);
     }
 
-    public function testClientThrowsAnErrorWhenUnableToCreateStream()
-    {
-        \putenv('TMPDIR=/__________foooo');
-        \error_reporting(\E_ALL ^ \E_STRICT ^ \E_NOTICE);
-        $this->expectException(HttpException\RuntimeException::class);
-        $this->expectExceptionMessage('Unable to create temporary name for stream');
-
-        $options = [
-            'outputstream' => true,
-        ];
-        $client = new Client('http://foo.com', $options);
-
-        $adapter = $this->prophesize(Client\Adapter\AdapterInterface::class);
-        $adapter->willImplement(Client\Adapter\StreamInterface::class);
-
-        $client->setAdapter($adapter->reveal());
-
-        $request = $client->getRequest();
-
-        $acceptEncodingHeader = new AcceptEncoding();
-        $acceptEncodingHeader->addEncoding('foo', 1);
-        $request->getHeaders()->addHeader($acceptEncodingHeader);
-
-        $client->send();
-    }
-
     public function testDoRequestWithNoHostUri()
     {
         $this->expectException(HttpException\InvalidArgumentException::class);

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -9,6 +9,7 @@ namespace ZendTest\Http;
 
 use ArrayIterator;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use ReflectionMethod;
 use Zend\Http\Client;
 use Zend\Http\Client\Adapter\AdapterInterface;
@@ -904,5 +905,19 @@ class ClientTest extends TestCase
         $request->getHeaders()->addHeader($acceptEncodingHeader);
 
         $client->send();
+    }
+
+    public function testDoRequestWithNoHostUri()
+    {
+        $this->expectException(HttpException\InvalidArgumentException::class);
+
+        $client = new Client();
+        $class = new ReflectionClass(Client::class);
+        $method = $class->getMethod('doRequest');
+        $method->setAccessible(true);
+
+        $uri = new Http();
+
+        $method->invokeArgs($client, [$uri, 'GET']);
     }
 }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -24,10 +24,30 @@ use Zend\Http\Header\SetCookie;
 use Zend\Http\Request;
 use Zend\Http\Response;
 use Zend\Uri\Http;
+use Zend\Stdlib;
 use ZendTest\Http\TestAsset\ExtendedClient;
 
 class ClientTest extends TestCase
 {
+    private $originalErrorReporting;
+    private $tmpDir;
+
+    protected function setUp()
+    {
+        $this->originalErrorReporting = \error_reporting();
+        $this->tmpDir = \getenv('TMPDIR');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        \error_reporting($this->originalErrorReporting);
+        \putenv('TMPDIR=' . $this->tmpDir);
+
+        parent::tearDown();
+    }
+
     public function testIfCookiesAreSticky()
     {
         $initialCookies = [
@@ -119,6 +139,8 @@ class ClientTest extends TestCase
         $client->addCookie('test', 0);
         $client->addCookie('test2', '0');
         $client->addCookie('test3', false);
+
+        $this->assertCount(3, $client->getCookies());
     }
 
     public function testIfNullValueCookiesThrowsException()
@@ -183,6 +205,17 @@ class ClientTest extends TestCase
      * @group 2774
      * @group 2745
      */
+    public function testArgSeparatorDefaultsWithNoIniSetting()
+    {
+        \ini_set('arg_separator.output', false);
+        $client = new Client();
+        $this->assertEquals('&', $client->getArgSeparator());
+    }
+
+    /**
+     * @group 2774
+     * @group 2745
+     */
     public function testCanOverrideArgSeparator()
     {
         $client = new Client();
@@ -192,7 +225,7 @@ class ClientTest extends TestCase
 
     public function testClientUsesAcceptEncodingHeaderFromRequestObject()
     {
-        $client = new Client();
+        $client = new Client('http://foo.com');
 
         $client->setAdapter(Test::class);
 
@@ -264,6 +297,75 @@ class ClientTest extends TestCase
         // response should be the second response, since third response should not
         // be requested, due to the maxredirects = 1 limit
         $this->assertEquals($response->getContent(), 'Page #2');
+    }
+
+    public function testSendWithNotUriPath()
+    {
+        $testAdapter = new Test();
+        $testAdapter->setResponse(
+            'HTTP/1.1 200 OK' . "\r\n\r\n"
+            . 'Page #1'
+        );
+
+        $uri = new Http();
+        $uri->setHost('www.example.org');
+
+        $this->assertNull($uri->getPath());
+
+        $client = new Client($uri, [
+            'adapter' => $testAdapter,
+            'storeresponse' => true,
+        ]);
+
+        // do the request
+        $response = $client->setMethod('GET')->send();
+
+        $this->assertEquals($response->getContent(), 'Page #1');
+    }
+
+    public function testHappyPathWithDispatch()
+    {
+        $testAdapter = new Test();
+        $testAdapter->setResponse(
+            'HTTP/1.1 200 OK' . "\r\n\r\n"
+            . 'Page #1'
+        );
+
+        $client = new Client('http://www.example.org/part1', [
+            'adapter' => $testAdapter,
+            'storeresponse' => true,
+        ]);
+
+        $request = new Request();
+        $request->setUri('http://www.example.org/part1');
+        $response = new Response();
+
+        // do the request
+        $response = $client->setMethod('GET')->dispatch($request, $response);
+
+        $this->assertEquals($response->getContent(), 'Page #1');
+    }
+
+    public function testDispatchWithBaseInterface()
+    {
+        $this->expectException(HttpException\UnexpectedValueException::class);
+
+        $testAdapter = new Test();
+        $testAdapter->setResponse(
+            'HTTP/1.1 200 OK' . "\r\n\r\n"
+            . 'Page #1'
+        );
+
+        $client = new Client('http://www.example.org/part1', [
+            'adapter' => $testAdapter,
+            'storeresponse' => true,
+        ]);
+
+        $request = $this->prophesize(Stdlib\RequestInterface::class);
+        $response = new Response();
+
+        // do the request
+        $client->setMethod('GET')->dispatch($request->reveal(), $response);
     }
 
     public function testIfClientDoesNotLooseAuthenticationOnRedirect()
@@ -486,6 +588,7 @@ class ClientTest extends TestCase
     public function testClientRequestMethod()
     {
         $request = new Request();
+        $request->setUri('http://foo.com');
         $request->setMethod(Request::METHOD_POST);
         $request->getPost()->set('data', 'random');
 
@@ -507,7 +610,7 @@ class ClientTest extends TestCase
         $this->assertEquals('application/x-www-form-urlencoded', $client->getEncType());
 
         $client->setEncType(null);
-        $this->assertNull($client->getEncType());
+        $this->assertSame('', $client->getEncType());
     }
 
     /**
@@ -518,6 +621,7 @@ class ClientTest extends TestCase
         $client = new Client();
         $client->setEncType('application/x-www-form-urlencoded');
         $request = new Request();
+        $request->setUri('http://foo.com');
         $request->setMethod(Request::METHOD_POST);
         $request->getPost()->set('foo', 'bar');
         $request->getPost()->set('baz', 'foo');
@@ -541,7 +645,8 @@ class ClientTest extends TestCase
      */
     public function testUriCorrectlyDeterminesWhetherOrNotItIsAValidRelativeUri($uri, $isValidRelativeURI)
     {
-        $client = new Client($uri);
+        $client = new Client('http://www.domain.com');
+        $client->setUri($uri);
         $this->assertSame($isValidRelativeURI, $client->getUri()->isValidRelative());
 
         $client->setAdapter(Test::class);
@@ -636,5 +741,164 @@ class ClientTest extends TestCase
         $response = $client->getResponse();
 
         self::assertSame($response->getBody(), file_get_contents($tmpFile));
+    }
+
+    public function testClientRequestWillNotThrowExceptionOnResponseWithNoCookies()
+    {
+        $request = new Request();
+        $request->setUri('http://www.domain.com');
+        $request->setMethod(Request::METHOD_POST);
+        $request->getPost()->set('data', 'random');
+
+        $response = new Response();
+
+        $adapter = new Test();
+
+        $adapter->setResponse([
+            0 => $response,
+        ]);
+
+        $client = new Client();
+        $client->setAdapter($adapter);
+        $client->send($request);
+
+        $this->assertCount(0, $client->getCookies());
+    }
+
+    public function testClientRequestWillSaveCookiesAndReuseThem()
+    {
+        $cookies = new Cookies();
+        $cookies->addCookie(new SetCookie('foo', 'far', null, '/', 'www.domain.com'));
+        $cookies->addCookie(new SetCookie('bar', 'far', null, '/', 'www.domain.com'));
+
+        $request = new Request();
+        $request->setUri('http://www.domain.com');
+        $request->setMethod(Request::METHOD_POST);
+        $request->getPost()->set('data', 'random');
+
+        $response = new Response();
+        $response->getHeaders()->addHeaders($cookies->getAllCookies());
+
+        $adapter = new Test();
+
+        $adapter->setResponse([
+            0 => $response,
+        ]);
+
+        $client = new Client();
+        $client->setAdapter($adapter);
+        $client->send($request);
+
+        $this->assertCount(2, $client->getCookies());
+
+        $request2 = new Request();
+        $request2->setUri('http://www.domain.com');
+
+        $client->send($request2);
+
+        $lastRawRequest = $client->getLastRawRequest();
+        $this->assertContains("\r\nCookie: foo=far; bar=far\r\n", $lastRawRequest);
+    }
+
+    public function testClientRequestWillSaveCookiesAndReuseThemWithNullPathUri()
+    {
+        $cookies = new Cookies();
+        $cookies->addCookie(new SetCookie('foo', 'far', null, '/', 'www.domain.com'));
+        //$cookies->addCookie(new SetCookie('foo2', 'far', null, '/foo', 'www.domain.com'));
+        $cookies->addCookie(new SetCookie('bar', 'far', null, '/', 'www.domain.com'));
+
+        $uri = new Http();
+        $uri->setHost('www.domain.com');
+
+        $this->assertNull($uri->getPath());
+
+        $request = new Request();
+        $request->setUri('http://www.domain.com');
+        $request->setMethod(Request::METHOD_POST);
+        $request->getPost()->set('data', 'random');
+
+        $response = new Response();
+        $response->getHeaders()->addHeaders($cookies->getAllCookies());
+
+        $adapter = new Test();
+
+        $adapter->setResponse([
+            0 => $response,
+        ]);
+
+        $client = new Client();
+        $client->setAdapter($adapter);
+        $client->send($request);
+
+        $this->assertCount(2, $client->getCookies());
+
+        $request2 = new Request();
+        $request2->setUri($uri);
+
+        $client->send($request2);
+
+        $lastRawRequest = $client->getLastRawRequest();
+        $this->assertContains("\r\nCookie: foo=far; bar=far\r\n", $lastRawRequest);
+    }
+
+    public function testClientRequestWillNotReuseCookiesFromDifferentDomain()
+    {
+        $cookies = new Cookies();
+        $cookies->addCookie(new SetCookie('foo', 'far', null, '/', 'www.domain.com'));
+        $cookies->addCookie(new SetCookie('bar', 'far', null, '/', 'www.domain.com'));
+
+        $request = new Request();
+        $request->setUri('http://www.domain.com');
+        $request->setMethod(Request::METHOD_POST);
+        $request->getPost()->set('data', 'random');
+
+        $response = new Response();
+        $response->getHeaders()->addHeaders($cookies->getAllCookies());
+
+        $adapter = new Test();
+
+        $adapter->setResponse([
+            0 => $response,
+        ]);
+
+        $client = new Client();
+        $client->setAdapter($adapter);
+        $client->send($request);
+
+        $this->assertCount(2, $client->getCookies());
+
+        $request2 = new Request();
+        $request2->setUri('http://foo.com');
+
+        $client->send($request2);
+
+        $lastRawRequest = $client->getLastRawRequest();
+        $this->assertNotContains("\r\nCookie: foo=far; bar=far\r\n", $lastRawRequest);
+    }
+
+    public function testClientThrowsAnErrorWhenUnableToCreateStream()
+    {
+        \putenv('TMPDIR=/__________foooo');
+        \error_reporting(\E_ALL ^ \E_STRICT ^ \E_NOTICE);
+        $this->expectException(HttpException\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to create temporary name for stream');
+
+        $options = [
+            'outputstream' => true,
+        ];
+        $client = new Client('http://foo.com', $options);
+
+        $adapter = $this->prophesize(Client\Adapter\AdapterInterface::class);
+        $adapter->willImplement(Client\Adapter\StreamInterface::class);
+
+        $client->setAdapter($adapter->reveal());
+
+        $request = $client->getRequest();
+
+        $acceptEncodingHeader = new AcceptEncoding();
+        $acceptEncodingHeader->addEncoding('foo', 1);
+        $request->getHeaders()->addHeader($acceptEncodingHeader);
+
+        $client->send();
     }
 }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -632,26 +632,17 @@ class ClientTest extends TestCase
         $this->assertContains('foo=bar&baz=foo', $rawRequest);
     }
 
-    public function uriDataProvider()
+    public function testRelativeUriInConstructorIsNotAllowed()
     {
-        return [
-            'valid-relative' => ['/example', true],
-            'invalid-absolute' => ['http://localhost/example', false],
-        ];
+        $this->expectException(HttpException\InvalidArgumentException::class);
+        $client = new Client('/example');
     }
 
-    /**
-     * @dataProvider uriDataProvider
-     */
-    public function testUriCorrectlyDeterminesWhetherOrNotItIsAValidRelativeUri($uri, $isValidRelativeURI)
+    public function testRelativeUriIsNotAllowed()
     {
+        $this->expectException(HttpException\InvalidArgumentException::class);
         $client = new Client('http://www.domain.com');
-        $client->setUri($uri);
-        $this->assertSame($isValidRelativeURI, $client->getUri()->isValidRelative());
-
-        $client->setAdapter(Test::class);
-        $client->send();
-        $this->assertSame($isValidRelativeURI, $client->getUri()->isValidRelative());
+        $client->setUri('/example');
     }
 
     public function portChangeDataProvider()

--- a/test/CookiesTest.php
+++ b/test/CookiesTest.php
@@ -44,6 +44,49 @@ class CookiesTest extends TestCase
         $this->assertSame($header, $response->getCookie('http://www.zend.com', 'foo'));
     }
 
+    public function testGetAllCookiesStringObject()
+    {
+        $response = new Response();
+        $headers = new Headers();
+        $header = new SetCookie('foo', 'bar');
+        $header->setDomain('www.zend.com');
+        $header->setPath('/');
+        $header2 = new SetCookie('foo2', 'bar2');
+        $header2->setDomain('www.zend2.com');
+        $header2->setPath('/');
+        $headers->addHeader($header);
+        $headers->addHeader($header2);
+        $response->setHeaders($headers);
+
+        $response = Cookies::fromResponse($response, 'http://www.zend.com');
+        $result = $response->getAllCookies(Cookies::COOKIE_OBJECT);
+        $this->assertSame([$header, $header2], $result);
+    }
+
+    public function testGetAllCookiesStringArray()
+    {
+        $response = new Response();
+        $headers = new Headers();
+        $header = new SetCookie('foo', 'bar');
+        $header->setDomain('www.zend.com');
+        $header->setPath('/');
+        $header2 = new SetCookie('foo2', 'bar2');
+        $header2->setDomain('www.zend2.com');
+        $header2->setPath('/');
+        $headers->addHeader($header);
+        $headers->addHeader($header2);
+        $response->setHeaders($headers);
+
+        $expected = [
+            'Set-Cookie: foo=bar; Domain=www.zend.com; Path=/',
+            'Set-Cookie: foo2=bar2; Domain=www.zend2.com; Path=/',
+        ];
+
+        $response = Cookies::fromResponse($response, 'http://www.zend.com');
+        $result = $response->getAllCookies(Cookies::COOKIE_STRING_ARRAY);
+        $this->assertSame($expected, $result);
+    }
+
     public function testRequestCanHaveArrayCookies()
     {
         $_COOKIE = [

--- a/test/Exception/UnexpectedValueExceptionTest.php
+++ b/test/Exception/UnexpectedValueExceptionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ZendTest\Http\Exception;
+
+use ArrayObject;
+use Zend\Http\Exception\UnexpectedValueException;
+use PHPUnit\Framework\TestCase;
+
+class UnexpectedValueExceptionTest extends TestCase
+{
+    public function testUnexpectedTypeWithObjectType()
+    {
+        $object = new ArrayObject();
+        $exception = UnexpectedValueException::unexpectedType('foo', $object);
+
+        $this->assertSame('Expected foo. ArrayObject given', $exception->getMessage());
+    }
+
+    public function testUnexpectedTypeWithScalarType()
+    {
+        $exception = UnexpectedValueException::unexpectedType('foo', 5);
+
+        $this->assertSame('Expected foo. integer given', $exception->getMessage());
+    }
+}

--- a/test/Header/SetCookieTest.php
+++ b/test/Header/SetCookieTest.php
@@ -146,7 +146,7 @@ class SetCookieTest extends TestCase
         $this->assertEquals('/accounts', $setCookieHeader->getPath());
         $this->assertEquals('Wed, 13-Jan-2021 22:23:01 GMT', $setCookieHeader->getExpires());
         $this->assertTrue($setCookieHeader->isSecure());
-        $this->assertTrue($setCookieHeader->isHttponly());
+        $this->assertTrue($setCookieHeader->isHttpOnly());
 
         $setCookieHeader = SetCookie::fromString(
             'set-cookie: myname=myvalue; Domain=docs.foo.com; Path=/accounts;'
@@ -310,7 +310,7 @@ class SetCookieTest extends TestCase
         $this->assertNull($setCookieHeader->getDomain());
         $this->assertNull($setCookieHeader->getPath());
         $this->assertNull($setCookieHeader->isSecure());
-        $this->assertNull($setCookieHeader->isHttponly());
+        $this->assertNull($setCookieHeader->isHttpOnly());
     }
 
     public function testSetCookieFieldValueIsEmptyStringWhenNameIsUnset()

--- a/test/HeadersTest.php
+++ b/test/HeadersTest.php
@@ -441,4 +441,10 @@ class HeadersTest extends TestCase
         $this->expectExceptionMessage('Invalid header value detected');
         $headers->get('Location');
     }
+
+    public function testHeadersFromStringFactoryWithNoCurrentLineShouldThrowException()
+    {
+        $this->expectException(RuntimeException::class);
+        Headers::fromString(" Fake foo\r\n -bar");
+    }
 }

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -678,6 +678,14 @@ REQ;
         $this->assertEquals($fixture, $request->getBody());
     }
 
+    public function test100ContinueWithInvalidContent()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid response content');
+
+        Response::fromString("HTTP/1.1 100 Continue\r\n");
+    }
+
     /**
      * Helper function: read test response from file
      *

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -16,6 +16,23 @@ use Zend\Http\Response;
 
 class ResponseTest extends TestCase
 {
+
+    private $originalErrorReporting;
+
+    protected function setUp()
+    {
+        $this->originalErrorReporting = \error_reporting();
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        \error_reporting($this->originalErrorReporting);
+
+        parent::tearDown();
+    }
+
     public function validHttpVersions()
     {
         yield 'http/1.0' => ['1.0'];
@@ -224,6 +241,35 @@ REQ;
         $this->assertEquals('deflate', $res->getHeaders()->get('Content-encoding')->getFieldValue());
         $this->assertEquals('0b13cb193de9450aa70a6403e2c9902f', md5($res->getBody()));
         $this->assertEquals('ad62c21c3aa77b6a6f39600f6dd553b8', md5($res->getContent()));
+    }
+
+    public function testDeflateResponseWithDeflateError()
+    {
+        \error_reporting(E_ALL ^ \E_STRICT ^ \E_WARNING);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('An error occurred during inflation');
+
+        $responseTest = <<<'REQ'
+HTTP/1.1 200 OK
+Date: Sun, 25 Jun 2006 19:38:02 GMT
+Server: Apache
+X-powered-by: PHP/5.1.4-pl3-gentoo
+Content-encoding: deflate
+Vary: Accept-Encoding
+Content-length: 300
+Connection: close
+Content-type: text/html
+
+REQ;
+
+        // uncompressed data is more than 32768 times the length of the compressed input data
+        $data = \str_repeat('1', 10000000);
+
+        $responseTest .= "\n" . \gzdeflate($data);
+
+        $res = Response::fromString($responseTest);
+        $res->getBody();
     }
 
     public function testDeflateResponseWithEmptyBody()


### PR DESCRIPTION
- some fixes on PHPDoc 
- added checks on types when needed

### Changed

- Throw an exception when unable to uncompress response content
- Relative URIs are not allowed anymore in `Zend\Http\Client`.
  Anyway, usage of relative URIs has no sense and no adapter can handle it.

### Fixed

- Fixed `Zend\Http\Cookies::getAllCookies(Zend\Http\Cookies::COOKIE_STRING_ARRAY)`.
- Fixed `Zend\Http\Cookies::getAllCookies(Zend\Http\Cookies::COOKIE_STRING_CONCAT)`.
- Fixed use of HTTP URIs with empty path in Request
