### PR TITLE
Deprecated multiple behavior methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Deprecated
 
-- Nothing.
+- `Zend\Http\Request::getHeader()` is deprecated
+- `Zend\Http\Request::getHeaders()` with arguments is deprecated
+- `Zend\Http\Request::getQuery()` with arguments is deprecated
+- `Zend\Http\Request::getPost()` with arguments is deprecated
+- `Zend\Http\Request::getFiles()` with arguments is deprecated
 
 ### Removed
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -274,6 +274,11 @@ class Request extends AbstractMessage implements RequestInterface
             return $this->queryParams;
         }
 
+        trigger_error(
+            'Getting specific query parameter is deprecated',
+            E_USER_DEPRECATED
+        );
+
         return $this->queryParams->get($name, $default);
     }
 
@@ -306,6 +311,11 @@ class Request extends AbstractMessage implements RequestInterface
         if ($name === null) {
             return $this->postParams;
         }
+
+        trigger_error(
+            'Getting specific post parameter is deprecated',
+            E_USER_DEPRECATED
+        );
 
         return $this->postParams->get($name, $default);
     }
@@ -351,6 +361,11 @@ class Request extends AbstractMessage implements RequestInterface
             return $this->fileParams;
         }
 
+        trigger_error(
+            'Getting specific file parameter is deprecated',
+            E_USER_DEPRECATED
+        );
+
         return $this->fileParams->get($name, $default);
     }
 
@@ -373,6 +388,11 @@ class Request extends AbstractMessage implements RequestInterface
             return $this->headers;
         }
 
+        trigger_error(
+            'Getting specific header is deprecated',
+            E_USER_DEPRECATED
+        );
+
         if ($this->headers->has($name)) {
             return $this->headers->get($name);
         }
@@ -390,6 +410,16 @@ class Request extends AbstractMessage implements RequestInterface
      */
     public function getHeader($name, $default = false)
     {
+        trigger_error(
+            sprintf(
+                '%s::%s is deprecated Please get it from %s::getHeaders().',
+                __CLASS__,
+                __METHOD__,
+                __CLASS__
+            ),
+            E_USER_DEPRECATED
+        );
+
         return $this->getHeaders($name, $default);
     }
 

--- a/test/PhpEnvironment/RequestTest.php
+++ b/test/PhpEnvironment/RequestTest.php
@@ -56,6 +56,8 @@ class RequestTest extends TestCase
         $_SERVER = $this->originalEnvironment['server'];
         $_ENV    = $this->originalEnvironment['env'];
         $_FILES  = $this->originalEnvironment['files'];
+
+        \error_reporting(E_ALL);
     }
 
     /**
@@ -699,6 +701,8 @@ class RequestTest extends TestCase
         $request->setEnv($p);
 
         $default = 15;
+
+        \error_reporting(E_ALL ^ \E_USER_DEPRECATED);
         $this->assertSame($default, $request->getQuery('baz', $default));
         $this->assertSame($default, $request->getPost('baz', $default));
         $this->assertSame($default, $request->getFiles('baz', $default));
@@ -706,6 +710,7 @@ class RequestTest extends TestCase
         $this->assertSame($default, $request->getEnv('baz', $default));
         $this->assertSame($default, $request->getHeaders('baz', $default));
         $this->assertSame($default, $request->getHeader('baz', $default));
+        \error_reporting(E_ALL);
     }
 
     public function testRetrievingASingleValueForParameters()
@@ -720,11 +725,13 @@ class RequestTest extends TestCase
         $request->setServer($p);
         $request->setEnv($p);
 
+        \error_reporting(E_ALL ^ \E_USER_DEPRECATED);
         $this->assertSame('bar', $request->getQuery('foo'));
         $this->assertSame('bar', $request->getPost('foo'));
         $this->assertSame('bar', $request->getFiles('foo'));
         $this->assertSame('bar', $request->getServer('foo'));
         $this->assertSame('bar', $request->getEnv('foo'));
+        \error_reporting(E_ALL);
 
         $headers = new Headers();
         $h = new GenericHeader('foo', 'bar');
@@ -733,7 +740,10 @@ class RequestTest extends TestCase
         $request->setHeaders($headers);
         $this->assertSame($headers, $request->getHeaders());
         $this->assertSame($h, $request->getHeaders()->get('foo'));
+
+        \error_reporting(E_ALL ^ \E_USER_DEPRECATED);
         $this->assertSame($h, $request->getHeader('foo'));
+        \error_reporting(E_ALL);
     }
 
     /**

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -20,6 +20,13 @@ use Zend\Uri\Uri;
 
 class RequestTest extends TestCase
 {
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        \error_reporting(E_ALL);
+    }
+
     public function testRequestFromStringFactoryCreatesValidRequest()
     {
         $string = "GET /foo?myparam=myvalue HTTP/1.1\r\n\r\nSome Content";
@@ -67,9 +74,11 @@ class RequestTest extends TestCase
         $request->setPost($p);
         $request->setFiles($p);
 
+        \error_reporting(E_ALL ^ \E_USER_DEPRECATED);
         $this->assertSame('bar', $request->getQuery('foo'));
         $this->assertSame('bar', $request->getPost('foo'));
         $this->assertSame('bar', $request->getFiles('foo'));
+        \error_reporting(E_ALL);
 
         $headers = new Headers();
         $h = new GenericHeader('foo', 'bar');
@@ -78,7 +87,10 @@ class RequestTest extends TestCase
         $request->setHeaders($headers);
         $this->assertSame($headers, $request->getHeaders());
         $this->assertSame($h, $request->getHeaders()->get('foo'));
+
+        \error_reporting(E_ALL ^ \E_USER_DEPRECATED);
         $this->assertSame($h, $request->getHeader('foo'));
+        \error_reporting(E_ALL);
     }
 
     public function testParameterRetrievalDefaultValue()
@@ -92,11 +104,14 @@ class RequestTest extends TestCase
         $request->setFiles($p);
 
         $default = 15;
+
+        \error_reporting(E_ALL ^ \E_USER_DEPRECATED);
         $this->assertSame($default, $request->getQuery('baz', $default));
         $this->assertSame($default, $request->getPost('baz', $default));
         $this->assertSame($default, $request->getFiles('baz', $default));
         $this->assertSame($default, $request->getHeaders('baz', $default));
         $this->assertSame($default, $request->getHeader('baz', $default));
+        \error_reporting(E_ALL);
     }
 
     public function testRequestPersistsRawBody()
@@ -342,11 +357,17 @@ class RequestTest extends TestCase
         $headers = $request->getHeaders();
         $this->assertFalse($headers->has('User-Agent'));
         $this->assertFalse($headers->get('User-Agent'));
+
+        \error_reporting(E_ALL ^ \E_USER_DEPRECATED);
         $this->assertSame('bar-baz', $request->getHeader('User-Agent', 'bar-baz'));
+        \error_reporting(E_ALL);
 
         $this->assertTrue($headers->has('useragent'));
         $this->assertInstanceOf(GenericHeader::class, $headers->get('useragent'));
         $this->assertSame('h4ckerbot', $headers->get('useragent')->getFieldValue());
+
+        \error_reporting(E_ALL ^ \E_USER_DEPRECATED);
         $this->assertSame('h4ckerbot', $request->getHeader('useragent')->getFieldValue());
+        \error_reporting(E_ALL);
     }
 }


### PR DESCRIPTION
In order to improve code quality and easily add type hints in a future release, I started to deprecate some methods with multiple behavior and different return types based on arguments.

- `Zend\Http\Request::getHeader()` is deprecated
- `Zend\Http\Request::getHeaders()` with arguments is deprecated
- `Zend\Http\Request::getQuery()` with arguments is deprecated
- `Zend\Http\Request::getPost()` with arguments is deprecated
- `Zend\Http\Request::getFiles()` with arguments is deprecated

The deprecation is for methods used as a "proxy".  
Clients can access to them getting the collection first.

```php
$request->getHeader('header-name'); // deprecated
$request->getHeaders('header-name'); // deprecated

$request->getHeaders()->get('header-name'); // currently suggested access
```

```php
$request->getQuery('name'); // deprecated

$request->getQuery()->get('name'); // currently suggested access
```


```php
$request->getPost('name'); // deprecated

$request->getPost()->get('name'); // currently suggested access
```

```php
$request->getFiles('name'); // deprecated

$request->getFiles()->get('name'); // currently suggested access
```

This will allow to introduce type hints for these methods in the future , something like:

```php
use Zend\Stdlib\ParametersInterface;
use Zend\Http\Headers;

class Request
{
    public function getHeaders(): Headers;
    public function getQuery(): ParametersInterface;
    public function getPost(): ParametersInterface;
    public function getFiles(): ParametersInterface;
}
``` 