### PR TITLE
Do not upper case first character of headers in socket adapter

### DIFF
--- a/src/Client/Adapter/Socket.php
+++ b/src/Client/Adapter/Socket.php
@@ -381,7 +381,7 @@ class Socket implements HttpAdapter, StreamInterface
         $request = $method . ' ' . $path . ' HTTP/' . $httpVer . "\r\n";
         foreach ($headers as $k => $v) {
             if (is_string($k)) {
-                $v = ucfirst($k) . ': ' . $v;
+                $v = $k . ': ' . $v;
             }
             $request .= $v . "\r\n";
         }

--- a/src/Client/Adapter/Test.php
+++ b/src/Client/Adapter/Test.php
@@ -132,7 +132,7 @@ class Test implements AdapterInterface
         $request = $method . ' ' . $path . ' HTTP/' . $httpVer . "\r\n";
         foreach ($headers as $k => $v) {
             if (is_string($k)) {
-                $v = ucfirst($k) . ': ' . $v;
+                $v = $k . ': ' . $v;
             }
             $request .= $v . "\r\n";
         }

--- a/test/Client/SocketTest.php
+++ b/test/Client/SocketTest.php
@@ -310,6 +310,24 @@ class SocketTest extends CommonHttpTests
     }
 
     /**
+     * Verifies that the headers are being set as given without changing any
+     * character case.
+     */
+    public function testCaseInsensitiveHeaders()
+    {
+        $this->_adapter->connect('localhost');
+        $requestString = $this->_adapter->write(
+            'GET',
+            new Uri('tcp://localhost:80/'),
+            '1.1',
+            ['x-test-header' => 'someTestHeader'],
+            'someTestBody'
+        );
+
+        $this->assertContains('x-test-header', $requestString);
+    }
+
+    /**
      * Data Providers
      */
 


### PR DESCRIPTION
This PR Fixes #160 which causes headers being upper cased for their first character in key which causes a fail request to a non HTTP 1.1 compliant API.

HTTP 1.1 defines that the headers should be case insensitive. This means there is also no reason for upper casing the first character.

- [x] Are you fixing a bug?
  - [x] Detail the original, incorrect behavior.
The first character in a headers "name"/"key" was being upper cased in default for Socket and Test adapter.
  - [x] Detail the new, expected behavior.
The headers using the Socket and Test adapter should not be be upper cased for the first character any more.