### PR TITLE
Remove support for the X-Original-Url and X-Rewrite-Url headers for 2.2 branch

### DIFF
--- a/src/PhpEnvironment/Request.php
+++ b/src/PhpEnvironment/Request.php
@@ -433,18 +433,6 @@ class Request extends HttpRequest
         $requestUri = null;
         $server     = $this->getServer();
 
-        // Check this first so IIS will catch.
-        $httpXRewriteUrl = $server->get('HTTP_X_REWRITE_URL');
-        if ($httpXRewriteUrl !== null) {
-            $requestUri = $httpXRewriteUrl;
-        }
-
-        // Check for IIS 7.0 or later with ISAPI_Rewrite
-        $httpXOriginalUrl = $server->get('HTTP_X_ORIGINAL_URL');
-        if ($httpXOriginalUrl !== null) {
-            $requestUri = $httpXOriginalUrl;
-        }
-
         // IIS7 with URL Rewrite: make sure we get the unencoded url
         // (double slash problem).
         $iisUrlRewritten = $server->get('IIS_WasUrlRewritten');
@@ -453,12 +441,10 @@ class Request extends HttpRequest
             return $unencodedUrl;
         }
 
+        $requestUri = $server->get('REQUEST_URI');
+
         // HTTP proxy requests setup request URI with scheme and host [and port]
         // + the URL path, only use URL path.
-        if (!$httpXRewriteUrl) {
-            $requestUri = $server->get('REQUEST_URI');
-        }
-
         if ($requestUri !== null) {
             return preg_replace('#^[^/:]+://[^/]+#', '', $requestUri);
         }

--- a/test/PhpEnvironment/RequestTest.php
+++ b/test/PhpEnvironment/RequestTest.php
@@ -114,16 +114,7 @@ class RequestTest extends TestCase
                     'SCRIPT_FILENAME' => '/var/web/html/index.php',
                 ),
                 '/index.php',
-                ''
-            ),
-            array(
-                array(
-                    'HTTP_X_REWRITE_URL' => '/index.php/news/3?var1=val1&var2=val2',
-                    'PHP_SELF'           => '/index.php/news/3',
-                    'SCRIPT_FILENAME'    => '/var/web/html/index.php',
-                ),
-                '/index.php',
-                ''
+                '',
             ),
             array(
                 array(


### PR DESCRIPTION
This patch modifies the logic of `Zend\Http\PhpEnvironment\Request::detectRequestUri()`
such that it will ignore the X-Original-Url and X-Rewrite-Url headers
when marshaling the request URI.

Please release a 2.2.11 including this patch based on https://github.com/zendframework/zend-http/commit/5234f4a9e8137b731ab95d6a17879d4eb8fb9e39 for https://framework.zend.com/security/advisory/ZF2018-01.