### PR TITLE
Detecting base url for console requests

### DIFF
--- a/src/PhpEnvironment/Request.php
+++ b/src/PhpEnvironment/Request.php
@@ -489,6 +489,11 @@ class Request extends HttpRequest
             // Backtrack up the SCRIPT_FILENAME to find the portion
             // matching PHP_SELF.
 
+            $argv = $this->getServer()->get('argv', []);
+            if (isset($argv[0]) && strpos($filename, $argv[0]) === 0) {
+                $filename = substr($filename, strlen($argv[0]));
+            }
+
             $baseUrl  = '/';
             $basename = basename($filename);
             if ($basename) {

--- a/test/PhpEnvironment/RequestTest.php
+++ b/test/PhpEnvironment/RequestTest.php
@@ -791,4 +791,18 @@ class RequestTest extends TestCase
         // If no baseUrl is detected at all, an empty string is returned.
         $this->assertEquals('', $url);
     }
+
+    public function testDetectCorrectBaseUrlForConsoleRequests()
+    {
+        $_SERVER['argv'] = ['/home/user/package/vendor/bin/phpunit'];
+        $_SERVER['argc'] = 1;
+        $_SERVER['SCRIPT_FILENAME'] = '/home/user/package/vendor/bin/phpunit';
+        $_SERVER['SCRIPT_NAME'] = '/home/user/package/vendor/bin/phpunit';
+        $_SERVER['PHP_SELF'] = '/home/user/package/vendor/bin/phpunit';
+
+        $request = new Request();
+        $request->setRequestUri('/path/query/phpunit');
+
+        $this->assertSame('', $request->getBaseUrl());
+    }
 }


### PR DESCRIPTION
Alternative solution for: https://github.com/zendframework/zend-test/pull/66

Related issue: https://github.com/zendframework/zend-test/issues/71

In `zend-test` on dispatch from test global variables are set and the base url is detected wrongly in `zend-http`. Please see test case for more details.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.