### PR TITLE
Fixed tests on PHP 7.2+

### DIFF
--- a/test/Header/DateTest.php
+++ b/test/Header/DateTest.php
@@ -39,7 +39,13 @@ class DateTest extends TestCase
         $date     = new DateTime(null, new DateTimeZone('GMT'));
         $interval = $dateHeader->date()->diff($date, 1);
 
-        $this->assertSame('+12 hours 00 minutes 00 seconds', $interval->format('%R%H hours %I minutes %S seconds'));
+        if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame('+11 hours 59 minutes 59 seconds', $interval->format('%R%H hours %I minutes %S seconds'));
+            $this->assertLessThan(1, $interval->f);
+            $this->assertGreaterThan(0, $interval->f);
+        } else {
+            $this->assertSame('+12 hours 00 minutes 00 seconds', $interval->format('%R%H hours %I minutes %S seconds'));
+        }
     }
 
     public function testDateFromTimestampCreatesValidDateHeader()
@@ -52,7 +58,13 @@ class DateTest extends TestCase
         $date     = new DateTime(null, new DateTimeZone('GMT'));
         $interval = $dateHeader->date()->diff($date, 1);
 
-        $this->assertSame('+12 hours 00 minutes 00 seconds', $interval->format('%R%H hours %I minutes %S seconds'));
+        if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame('+11 hours 59 minutes 59 seconds', $interval->format('%R%H hours %I minutes %S seconds'));
+            $this->assertLessThan(1, $interval->f);
+            $this->assertGreaterThan(0, $interval->f);
+        } else {
+            $this->assertSame('+12 hours 00 minutes 00 seconds', $interval->format('%R%H hours %I minutes %S seconds'));
+        }
     }
 
     public function testDateFromTimeStringDetectsBadInput()


### PR DESCRIPTION
DateTime incorporates microseconds
Tests were failing on PHP 7.2+.
See #166 

- [x] Is this related to quality assurance?
