### PR TITLE
Fix for timeout config parameter validation

### DIFF
--- a/src/Client/Adapter/Curl.php
+++ b/src/Client/Adapter/Curl.php
@@ -209,7 +209,7 @@ class Curl implements HttpAdapter, StreamInterface
             $connectTimeout = null;
         }
 
-        if ($connectTimeout !== null && !is_int($connectTimeout) && !is_numeric($connectTimeout)) {
+        if ($connectTimeout !== null && ! is_int($connectTimeout) && ! is_numeric($connectTimeout)) {
             throw new AdapterException\InvalidArgumentException(sprintf(
                 'integer or numeric string expected, got %s',
                 gettype($connectTimeout)

--- a/src/Client/Adapter/Curl.php
+++ b/src/Client/Adapter/Curl.php
@@ -209,7 +209,7 @@ class Curl implements HttpAdapter, StreamInterface
             $connectTimeout = null;
         }
 
-        if ($connectTimeout !== null && ! is_int($connectTimeout) && ! is_numeric($connectTimeout)) {
+        if ($connectTimeout !== null && ! is_numeric($connectTimeout)) {
             throw new AdapterException\InvalidArgumentException(sprintf(
                 'integer or numeric string expected, got %s',
                 gettype($connectTimeout)

--- a/src/Client/Adapter/Curl.php
+++ b/src/Client/Adapter/Curl.php
@@ -209,7 +209,7 @@ class Curl implements HttpAdapter, StreamInterface
             $connectTimeout = null;
         }
 
-        if ($connectTimeout !== null && (! is_int($connectTimeout) || ! is_numeric($connectTimeout))) {
+        if ($connectTimeout !== null && !is_int($connectTimeout) && !is_numeric($connectTimeout)) {
             throw new AdapterException\InvalidArgumentException(sprintf(
                 'integer or numeric string expected, got %s',
                 gettype($connectTimeout)

--- a/src/Client/Adapter/Socket.php
+++ b/src/Client/Adapter/Socket.php
@@ -263,7 +263,7 @@ class Socket implements HttpAdapter, StreamInterface
                 $connectTimeout = $this->config['timeout'];
             }
 
-            if ($connectTimeout !== null && (! is_int($connectTimeout) || ! is_numeric($connectTimeout))) {
+            if ($connectTimeout !== null && !is_int($connectTimeout) && !is_numeric($connectTimeout)) {
                 throw new AdapterException\InvalidArgumentException(sprintf(
                     'integer or numeric string expected, got %s',
                     gettype($connectTimeout)

--- a/src/Client/Adapter/Socket.php
+++ b/src/Client/Adapter/Socket.php
@@ -263,7 +263,7 @@ class Socket implements HttpAdapter, StreamInterface
                 $connectTimeout = $this->config['timeout'];
             }
 
-            if ($connectTimeout !== null && ! is_int($connectTimeout) && ! is_numeric($connectTimeout)) {
+            if ($connectTimeout !== null && ! is_numeric($connectTimeout)) {
                 throw new AdapterException\InvalidArgumentException(sprintf(
                     'integer or numeric string expected, got %s',
                     gettype($connectTimeout)

--- a/src/Client/Adapter/Socket.php
+++ b/src/Client/Adapter/Socket.php
@@ -263,7 +263,7 @@ class Socket implements HttpAdapter, StreamInterface
                 $connectTimeout = $this->config['timeout'];
             }
 
-            if ($connectTimeout !== null && !is_int($connectTimeout) && !is_numeric($connectTimeout)) {
+            if ($connectTimeout !== null && ! is_int($connectTimeout) && ! is_numeric($connectTimeout)) {
                 throw new AdapterException\InvalidArgumentException(sprintf(
                     'integer or numeric string expected, got %s',
                     gettype($connectTimeout)


### PR DESCRIPTION
Validation conditions for integer or numeric timeout was mutually exclusive, fixed.