### PR TITLE
Add missing directives in CSP

### DIFF
--- a/src/Header/ContentSecurityPolicy.php
+++ b/src/Header/ContentSecurityPolicy.php
@@ -21,31 +21,38 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
      */
     protected $validDirectiveNames = [
         // As per http://www.w3.org/TR/CSP/#directives
-        'default-src',
-        'script-src',
-        'object-src',
-        'style-src',
-        'img-src',
-        'media-src',
-        'frame-src',
-        'font-src',
-        'connect-src',
-        'sandbox',
-        'report-uri',
+        // Fetch directives
         'child-src',
+        'connect-src',
+        'default-src',
+        'font-src',
+        'frame-src',
+        'img-src',
         'manifest-src',
-        'worker-src',
+        'media-src',
+        'object-src',
         'prefetch-src',
+        'script-src',
         'script-src-elem',
         'script-src-attr',
+        'style-src',
         'style-src-elem',
         'style-src-attr',
+        'worker-src',
+
+        // Document directives
         'base-uri',
         'plugin-types',
+        'sandbox',
+
+        // Navigation directives
         'form-action',
         'frame-ancestors',
         'navigate-to',
-        'report-to'
+
+        // Reporting directives
+        'report-uri',
+        'report-to',
     ];
 
     /**

--- a/src/Header/ContentSecurityPolicy.php
+++ b/src/Header/ContentSecurityPolicy.php
@@ -8,7 +8,7 @@
 namespace Zend\Http\Header;
 
 /**
- * Content Security Policy 1.0 Header
+ * Content Security Policy Level 3 Header
  *
  * @link http://www.w3.org/TR/CSP/
  */
@@ -32,6 +32,20 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
         'connect-src',
         'sandbox',
         'report-uri',
+        'child-src',
+        'manifest-src',
+        'worker-src',
+        'prefetch-src',
+        'script-src-elem',
+        'script-src-attr',
+        'style-src-elem',
+        'style-src-attr',
+        'base-uri',
+        'plugin-types',
+        'form-action',
+        'frame-ancestors',
+        'navigate-to',
+        'report-to'
     ];
 
     /**

--- a/test/Header/ContentSecurityPolicyTest.php
+++ b/test/Header/ContentSecurityPolicyTest.php
@@ -192,16 +192,16 @@ class ContentSecurityPolicyTest extends TestCase
      * @dataProvider directivesProvider
      *
      * @param string $directive
-     * @param string[] $value
+     * @param string[] $values
      * @param string $expected
      */
     public function testContentSecurityPolicySetDirectiveThrowsExceptionIfMissingDirectiveNameGiven(
         $directive,
-        array $value,
+        array $values,
         $expected
     ) {
         $csp = new ContentSecurityPolicy();
-        $csp->setDirective($directive, $value);
+        $csp->setDirective($directive, $values);
 
         self::assertSame($expected, $csp->toString());
     }

--- a/test/Header/ContentSecurityPolicyTest.php
+++ b/test/Header/ContentSecurityPolicyTest.php
@@ -189,7 +189,7 @@ class ContentSecurityPolicyTest extends TestCase
     }
 
     /**
-     * @dataProvider directivesProvider
+     * @dataProvider validDirectives
      *
      * @param string $directive
      * @param string[] $values
@@ -206,7 +206,7 @@ class ContentSecurityPolicyTest extends TestCase
         self::assertSame($expected, $csp->toString());
     }
 
-    public static function directivesProvider()
+    public static function validDirectives()
     {
         return [
             ['child-src', ["'self'"],"Content-Security-Policy: child-src 'self';"],

--- a/test/Header/ContentSecurityPolicyTest.php
+++ b/test/Header/ContentSecurityPolicyTest.php
@@ -219,18 +219,14 @@ class ContentSecurityPolicyTest extends TestCase
             ['style-src-attr', ["'self'"], "Content-Security-Policy: style-src-attr 'self';"],
             ['base-uri', ["'self'", "'unsafe-inline'"], "Content-Security-Policy: base-uri 'self' 'unsafe-inline';"],
             ['plugin-types', ['text/csv'], 'Content-Security-Policy: plugin-types text/csv;'],
-            ['form-action',
-                [
-                    'http://*.example.com',
-                    "'self'"
-                ],
+            [
+                'form-action',
+                ['http://*.example.com', "'self'"],
                 "Content-Security-Policy: form-action http://*.example.com 'self';"
             ],
-            ['frame-ancestors',
-                [
-                    'http://*.example.com',
-                    "'self'"
-                ],
+            [
+                'frame-ancestors',
+                ['http://*.example.com', "'self'"],
                 "Content-Security-Policy: frame-ancestors http://*.example.com 'self';"
             ],
             ['navigate-to', ['example.com'], 'Content-Security-Policy: navigate-to example.com;'],

--- a/test/Header/ContentSecurityPolicyTest.php
+++ b/test/Header/ContentSecurityPolicyTest.php
@@ -188,24 +188,6 @@ class ContentSecurityPolicyTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider validDirectives
-     *
-     * @param string $directive
-     * @param string[] $values
-     * @param string $expected
-     */
-    public function testContentSecurityPolicySetDirectiveThrowsExceptionIfMissingDirectiveNameGiven(
-        $directive,
-        array $values,
-        $expected
-    ) {
-        $csp = new ContentSecurityPolicy();
-        $csp->setDirective($directive, $values);
-
-        self::assertSame($expected, $csp->toString());
-    }
-
     public static function validDirectives()
     {
         return [
@@ -232,6 +214,24 @@ class ContentSecurityPolicyTest extends TestCase
             ['navigate-to', ['example.com'], 'Content-Security-Policy: navigate-to example.com;'],
             ['sandbox', ['allow-forms'], 'Content-Security-Policy: sandbox allow-forms;'],
         ];
+    }
+
+    /**
+     * @dataProvider validDirectives
+     *
+     * @param string $directive
+     * @param string[] $values
+     * @param string $expected
+     */
+    public function testContentSecurityPolicySetDirectiveThrowsExceptionIfMissingDirectiveNameGiven(
+        $directive,
+        array $values,
+        $expected
+    ) {
+        $csp = new ContentSecurityPolicy();
+        $csp->setDirective($directive, $values);
+
+        self::assertSame($expected, $csp->toString());
     }
 
     /**

--- a/test/Header/ContentSecurityPolicyTest.php
+++ b/test/Header/ContentSecurityPolicyTest.php
@@ -187,4 +187,54 @@ class ContentSecurityPolicyTest extends TestCase
             $headers->toString()
         );
     }
+
+    /**
+     * @dataProvider directivesProvider
+     *
+     * @param string $directive
+     * @param string[] $value
+     * @param string $expected
+     */
+    public function testContentSecurityPolicySetDirectiveThrowsExceptionIfMissingDirectiveNameGiven(
+        $directive,
+        array $value,
+        $expected
+    ) {
+        $csp = new ContentSecurityPolicy();
+        $csp->setDirective($directive, $value);
+
+        self::assertSame($expected, $csp->toString());
+    }
+
+    public static function directivesProvider()
+    {
+        return [
+            ['child-src', ["'self'"],"Content-Security-Policy: child-src 'self';"],
+            ['manifest-src', ["'self'"], "Content-Security-Policy: manifest-src 'self';"],
+            ['worker-src', ["'self'"], "Content-Security-Policy: worker-src 'self';"],
+            ['prefetch-src', ["'self'"], "Content-Security-Policy: prefetch-src 'self';"],
+            ['script-src-elem', ["'self'"], "Content-Security-Policy: script-src-elem 'self';"],
+            ['script-src-attr', ["'self'"], "Content-Security-Policy: script-src-attr 'self';"],
+            ['style-src-elem', ["'self'"], "Content-Security-Policy: style-src-elem 'self';"],
+            ['style-src-attr', ["'self'"], "Content-Security-Policy: style-src-attr 'self';"],
+            ['base-uri', ["'self'", "'unsafe-inline'"], "Content-Security-Policy: base-uri 'self' 'unsafe-inline';"],
+            ['plugin-types', ['text/csv'], 'Content-Security-Policy: plugin-types text/csv;'],
+            ['form-action',
+                [
+                    'http://*.example.com',
+                    "'self'"
+                ],
+                "Content-Security-Policy: form-action http://*.example.com 'self';"
+            ],
+            ['frame-ancestors',
+                [
+                    'http://*.example.com',
+                    "'self'"
+                ],
+                "Content-Security-Policy: frame-ancestors http://*.example.com 'self';"
+            ],
+            ['navigate-to', ['example.com'], 'Content-Security-Policy: navigate-to example.com;'],
+            ['sandbox', ['allow-forms'], 'Content-Security-Policy: sandbox allow-forms;'],
+        ];
+    }
 }

--- a/test/Header/ContentSecurityPolicyTest.php
+++ b/test/Header/ContentSecurityPolicyTest.php
@@ -233,4 +233,19 @@ class ContentSecurityPolicyTest extends TestCase
             ['sandbox', ['allow-forms'], 'Content-Security-Policy: sandbox allow-forms;'],
         ];
     }
+
+    /**
+     * @dataProvider validDirectives
+     *
+     * @param string $directive
+     * @param string[] $values
+     * @param string $header
+     */
+    public function testFromString($directive, array $values, $header)
+    {
+        $contentSecurityPolicy = ContentSecurityPolicy::fromString($header);
+
+        self::assertArrayHasKey($directive, $contentSecurityPolicy->getDirectives());
+        self::assertSame(implode(' ', $values), $contentSecurityPolicy->getDirectives()[$directive]);
+    }
 }


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

Some directives are missing in Fetch directive
* child-src
* manifest-src
* worker-src
* prefetch-src
* script-src-elem
* script-src-attr
* style-src-elem
* style-src-attr


And some Navigation, Document and Reporting directives are missing.
- base-uri
- plugin-types
- form-action
- frame-ancestors
- navigate-to
- report-to

### Code to reproduce the issue

```php
$csp = new ContentSecurityPolicy();
$csp->setDirective('worker-src', ['https://*.google.com', 'http://foo.com']);
$csp->toString();
```

### Actual result

Throw a Exception\InvalidArgumentException


### New result

toString() should return "Content-Security-Policy: worker-src https://*.google.com http://foo.com;"


This PR fixes #163 