### PR TITLE
$argv[0] can be empty

### DIFF
--- a/src/PhpEnvironment/Request.php
+++ b/src/PhpEnvironment/Request.php
@@ -490,7 +490,7 @@ class Request extends HttpRequest
             // matching PHP_SELF.
 
             $argv = $this->getServer()->get('argv', []);
-            if (!empty($argv[0]) && is_string($argv[0]) && strpos($filename, $argv[0]) === 0) {
+            if (! empty($argv[0]) && is_string($argv[0]) && strpos($filename, $argv[0]) === 0) {
                 $filename = substr($filename, strlen($argv[0]));
             }
 

--- a/src/PhpEnvironment/Request.php
+++ b/src/PhpEnvironment/Request.php
@@ -489,9 +489,13 @@ class Request extends HttpRequest
             // Backtrack up the SCRIPT_FILENAME to find the portion
             // matching PHP_SELF.
 
-            $argv = $this->getServer()->get('argv', []);
-            if (! empty($argv[0]) && is_string($argv[0]) && strpos($filename, $argv[0]) === 0) {
-                $filename = substr($filename, strlen($argv[0]));
+            // Only for CLI requests argv[0] contains script filename
+            // @see https://www.php.net/manual/en/reserved.variables.server.php
+            if (PHP_SAPI === 'cli') {
+                $argv = $this->getServer()->get('argv', []);
+                if (strpos($filename, $argv[0]) === 0) {
+                    $filename = substr($filename, strlen($argv[0]));
+                }
             }
 
             $baseUrl  = '/';

--- a/src/PhpEnvironment/Request.php
+++ b/src/PhpEnvironment/Request.php
@@ -490,7 +490,7 @@ class Request extends HttpRequest
             // matching PHP_SELF.
 
             $argv = $this->getServer()->get('argv', []);
-            if (isset($argv[0]) && strpos($filename, $argv[0]) === 0) {
+            if (!empty($argv[0]) && is_string($argv[0]) && strpos($filename, $argv[0]) === 0) {
                 $filename = substr($filename, strlen($argv[0]));
             }
 

--- a/src/PhpEnvironment/Request.php
+++ b/src/PhpEnvironment/Request.php
@@ -493,7 +493,7 @@ class Request extends HttpRequest
             // @see https://www.php.net/manual/en/reserved.variables.server.php
             if (PHP_SAPI === 'cli') {
                 $argv = $this->getServer()->get('argv', []);
-                if (strpos($filename, $argv[0]) === 0) {
+                if (isset($argv[0]) && is_string($argv[0]) && $argv[0] !== '' && strpos($filename, $argv[0]) === 0) {
                     $filename = substr($filename, strlen($argv[0]));
                 }
             }


### PR DESCRIPTION
In some cases $argv[0] can be empty and strpos will throw an "Empty needle" error. Therefore on line 493 $argv should be checked, that it is not empty and a string, instead of just checking its existence with isset().

Someone tried to attack one of my websites with "/index.php?++++hot=1&++++kw=%E8%93%9D%E7%89%99%E8%80%B3%E6%9C%BA&r=l" and this request caused an exception which was logged and where I found the error.

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
