### PR TITLE
process the response from a proxy with "HTTP/1.1 200 Connection established" header line

### DIFF
--- a/src/Client/Adapter/Curl.php
+++ b/src/Client/Adapter/Curl.php
@@ -494,7 +494,7 @@ class Curl implements HttpAdapter, StreamInterface
 
         // cURL automatically handles Proxy rewrites, remove the "HTTP/1.0 200 Connection established" string:
         $responseHeaders = preg_replace(
-            "/HTTP\/1.0\s*200\s*Connection\s*established\\r\\n\\r\\n/",
+            "/HTTP\/1.[01]\s*200\s*Connection\s*established\\r\\n\\r\\n/",
             '',
             $responseHeaders
         );

--- a/test/Client/CurlTest.php
+++ b/test/Client/CurlTest.php
@@ -524,4 +524,24 @@ class CurlTest extends CommonHttpTests
         }
         $this->assertNotNull($error, 'Failed to detect timeout in cURL adapter');
     }
+
+    /**
+     * @see https://github.com/zendframework/zend-http/pull/184
+     *
+     */
+    public function testMustRemoveProxyConnectionEstablishedLine()
+    {
+        $this->client->setUri($this->baseuri . 'testProxyResponse.php');
+
+        $adapter = new Adapter\Curl();
+
+        $this->client->setAdapter($adapter);
+        $this->client->setMethod('GET');
+        $this->client->send();
+
+        $response = $this->client->getResponse();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('work', $response->getBody());
+    }
 }

--- a/test/Client/_files/testProxyResponse.php
+++ b/test/Client/_files/testProxyResponse.php
@@ -1,0 +1,8 @@
+<?php
+
+echo "HTTP/1.1 200 Connection established\r\n\r\n";
+echo "HTTP/1.1 200 OK\r\n";
+echo "content-type: text/plain;charset=UTF-8\r\n";
+echo "server: Server\r\n";
+echo "\r\n";
+echo "work";


### PR DESCRIPTION
Fixing a bug when the response from a proxy contains first line as "HTTP/1.1 200 Connection established"