### PR TITLE
Fix $maxAge @param type in SetCookie::__construct

### DIFF
--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -197,7 +197,7 @@ class SetCookie implements MultipleHeaderInterface
      * @param   string              $domain
      * @param   bool                $secure
      * @param   bool                $httponly
-     * @param   string              $maxAge
+     * @param   int                 $maxAge
      * @param   int                 $version
      */
     public function __construct(


### PR DESCRIPTION
- [x] Is this related to quality assurance?
