### PR TITLE
Method setCookies on Client accepts name=>value pairs or SetCookie instances

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -11,6 +11,7 @@ use ArrayIterator;
 use Traversable;
 use Zend\Http\Client\Adapter\Curl;
 use Zend\Http\Client\Adapter\Socket;
+use Zend\Http\Header\SetCookie;
 use Zend\Stdlib;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\ErrorHandler;
@@ -603,7 +604,7 @@ class Client implements Stdlib\DispatchableInterface
     /**
      * Set an array of cookies
      *
-     * @param  array $cookies
+     * @param  array|SetCookie[] $cookies Cookies as name=>value pairs or instances of SetCookie.
      * @throws Exception\InvalidArgumentException
      * @return Client
      */
@@ -612,7 +613,11 @@ class Client implements Stdlib\DispatchableInterface
         if (is_array($cookies)) {
             $this->clearCookies();
             foreach ($cookies as $name => $value) {
-                $this->addCookie($name, $value);
+                if ($value instanceof SetCookie) {
+                    $this->addCookie($value);
+                } else {
+                    $this->addCookie($name, $value);
+                }
             }
         } else {
             throw new Exception\InvalidArgumentException('Invalid cookies passed as parameter, it must be an array');

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -588,8 +588,6 @@ class ClientTest extends TestCase
 
     /**
      * @dataProvider cookies
-     *
-     * @param string|array $cookies
      */
     public function testSetCookies(array $cookies)
     {

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -579,4 +579,34 @@ class ClientTest extends TestCase
         $client->send();
         $this->assertNull($client->getUri()->getPort());
     }
+
+    public function cookies()
+    {
+        yield 'name-value' => [['cookie-name' => 'cookie-value']];
+        yield 'SetCookie' => [[new SetCookie('cookie-name', 'cookie-value')]];
+    }
+
+    /**
+     * @dataProvider cookies
+     *
+     * @param string|array $cookies
+     */
+    public function testSetCookies(array $cookies)
+    {
+        $client = new Client();
+
+        $client->setCookies($cookies);
+
+        self::assertCount(1, $client->getCookies());
+        self::assertContainsOnlyInstancesOf(SetCookie::class, $client->getCookies());
+    }
+
+    public function testSetCookieAcceptOnlyArray()
+    {
+        $client = new Client();
+
+        $this->expectException(HttpException\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid cookies passed as parameter, it must be an array');
+        $client->setCookies(new SetCookie('name', 'value'));
+    }
 }


### PR DESCRIPTION
Per documentation it should be possible to pass array of SetCookie to Client::setCookies.

Fixes #114

See: https://docs.zendframework.com/zend-http/client/cookies/#usage

```php
$client->setUri($uri);
$client->setCookies($cookies->getMatchingCookies($uri));
```

and method `getMatchingCookies` return array of `SetCookie`.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.
