### PR TITLE
Content-Security-Policy implements MultipleHeaderInterface

### DIFF
--- a/src/Header/ContentSecurityPolicy.php
+++ b/src/Header/ContentSecurityPolicy.php
@@ -12,7 +12,7 @@ namespace Zend\Http\Header;
  *
  * @link http://www.w3.org/TR/CSP/
  */
-class ContentSecurityPolicy implements HeaderInterface
+class ContentSecurityPolicy implements MultipleHeaderInterface
 {
     /**
      * Valid directive names
@@ -153,5 +153,21 @@ class ContentSecurityPolicy implements HeaderInterface
     public function toString()
     {
         return sprintf('%s: %s', $this->getFieldName(), $this->getFieldValue());
+    }
+
+    public function toStringMultipleHeaders(array $headers)
+    {
+        $strings = [$this->toString()];
+        foreach ($headers as $header) {
+            if (! $header instanceof ContentSecurityPolicy) {
+                throw new Exception\RuntimeException(
+                    'The ContentSecurityPolicy multiple header implementation can only'
+                    . ' accept an array of ContentSecurityPolicy headers'
+                );
+            }
+            $strings[] = $header->toString();
+        }
+
+        return implode("\r\n", $strings) . "\r\n";
     }
 }

--- a/src/HeaderLoader.php
+++ b/src/HeaderLoader.php
@@ -36,6 +36,7 @@ class HeaderLoader extends PluginClassLoader
         'contentlocation'         => Header\ContentLocation::class,
         'contentmd5'              => Header\ContentMD5::class,
         'contentrange'            => Header\ContentRange::class,
+        'contentsecuritypolicy'   => Header\ContentSecurityPolicy::class,
         'contenttransferencoding' => Header\ContentTransferEncoding::class,
         'contenttype'             => Header\ContentType::class,
         'cookie'                  => Header\Cookie::class,


### PR DESCRIPTION
This header can be provided multiple times
Ref: https://w3c.github.io/webappsec-csp/#multiple-policies

Fixes #159 

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

/cc @markushausammann