### PR TITLE
Add notes to documenation about issue with libcurl prior to 7.30.0

### DIFF
--- a/docs/book/client/adapters.md
+++ b/docs/book/client/adapters.md
@@ -239,6 +239,12 @@ choice for a HTTP adapter. It supports secure connections, proxies, and multiple
 authentication mechanisms. In particular, it is very performant with regards to
 transfering large files.
 
+> #### Known issue with libcurl prior to 7.30.0
+>
+> There is an issue with [incorrect headers length detection in libcurl](https://github.com/bagder/curl/pull/60)
+> prior to 7.30.0. It leads to problems with removing the Transfer-Encoding
+> header from the response. We encourage to update libcurl.
+
 ### Setting cURL options
 
 ```php


### PR DESCRIPTION
Resolves #24
Resolves #181

Version [7.30.0](https://curl.haxx.se/changes.html#7_30_0) has been released on 12 April 2013.
We are not gonna fix the issue of the external library in zend-http.

- [x] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
