### PR TITLE
Fix: decompressed response saved into file when streaming

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1184,7 +1184,7 @@ class Client implements Stdlib\DispatchableInterface
         // Set the Accept-encoding header if not set - depending on whether
         // zlib is available or not.
         if (! $this->getRequest()->getHeaders()->has('Accept-Encoding')) {
-            if (function_exists('gzinflate')) {
+            if (empty($this->config['outputstream']) && function_exists('gzinflate')) {
                 $headers['Accept-Encoding'] = 'gzip, deflate';
             } else {
                 $headers['Accept-Encoding'] = 'identity';


### PR DESCRIPTION
- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

When we set stream we'd like to get decompressed resource in the file.

Fixes #91

/cc @zerocrates 
