### PR TITLE
Fix exception notice "Undefined offset: 1"

### DIFF
--- a/src/Header/ContentSecurityPolicy.php
+++ b/src/Header/ContentSecurityPolicy.php
@@ -53,6 +53,12 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
         // Reporting directives
         'report-uri',
         'report-to',
+
+        // Other directives
+        'block-all-mixed-content',
+        'require-sri-for',
+        'trusted-types',
+        'upgrade-insecure-requests',
     ];
 
     /**
@@ -91,6 +97,21 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
                 (string) $name
             ));
         }
+
+        if ($name === 'block-all-mixed-content'
+            || $name === 'upgrade-insecure-requests'
+        ) {
+            if ($sources) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'Received value for %s directive; none expected',
+                    $name
+                ));
+            }
+
+            $this->directives[$name] = '';
+            return $this;
+        }
+
         if (empty($sources)) {
             if ('report-uri' === $name) {
                 if (isset($this->directives[$name])) {
@@ -98,6 +119,7 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
                 }
                 return $this;
             }
+
             $this->directives[$name] = "'none'";
             return $this;
         }
@@ -166,7 +188,7 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
         foreach ($this->directives as $name => $value) {
             $directives[] = sprintf('%s %s;', $name, $value);
         }
-        return implode(' ', $directives);
+        return str_replace(' ;', ';', implode(' ', $directives));
     }
 
     /**

--- a/src/Header/ContentSecurityPolicy.php
+++ b/src/Header/ContentSecurityPolicy.php
@@ -135,7 +135,10 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
             if ($token) {
                 list($directiveName, $directiveValue) = array_pad(explode(' ', $token, 2), 2, null);
                 if (! isset($header->directives[$directiveName])) {
-                    $header->setDirective($directiveName, [$directiveValue]);
+                    $header->setDirective(
+                        $directiveName,
+                        $directiveValue === null ? [] : [$directiveValue]
+                    );
                 }
             }
         }

--- a/src/Header/ContentSecurityPolicy.php
+++ b/src/Header/ContentSecurityPolicy.php
@@ -133,7 +133,7 @@ class ContentSecurityPolicy implements MultipleHeaderInterface
         foreach ($tokens as $token) {
             $token = trim($token);
             if ($token) {
-                list($directiveName, $directiveValue) = explode(' ', $token, 2);
+                list($directiveName, $directiveValue) = array_pad(explode(' ', $token, 2), 2, null);
                 if (! isset($header->directives[$directiveName])) {
                     $header->setDirective($directiveName, [$directiveValue]);
                 }

--- a/test/Header/ContentSecurityPolicyTest.php
+++ b/test/Header/ContentSecurityPolicyTest.php
@@ -213,6 +213,12 @@ class ContentSecurityPolicyTest extends TestCase
             ],
             ['navigate-to', ['example.com'], 'Content-Security-Policy: navigate-to example.com;'],
             ['sandbox', ['allow-forms'], 'Content-Security-Policy: sandbox allow-forms;'],
+
+            // Other directives
+            ['block-all-mixed-content', [], 'Content-Security-Policy: block-all-mixed-content;'],
+            ['require-sri-for', ['script', 'style'], 'Content-Security-Policy: require-sri-for script style;'],
+            ['trusted-types', ['*'], 'Content-Security-Policy: trusted-types *;'],
+            ['upgrade-insecure-requests', [], 'Content-Security-Policy: upgrade-insecure-requests;'],
         ];
     }
 
@@ -247,5 +253,28 @@ class ContentSecurityPolicyTest extends TestCase
 
         self::assertArrayHasKey($directive, $contentSecurityPolicy->getDirectives());
         self::assertSame(implode(' ', $values), $contentSecurityPolicy->getDirectives()[$directive]);
+    }
+
+    /**
+     * @return string
+     */
+    public function directivesWithoutValue()
+    {
+        yield ['block-all-mixed-content'];
+        yield ['upgrade-insecure-requests'];
+    }
+
+    /**
+     * @dataProvider directivesWithoutValue
+     *
+     * @param string $directive
+     */
+    public function testExceptionWhenProvideValueWithDirectiveWithoutValue($directive)
+    {
+        $csp = new ContentSecurityPolicy();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($directive);
+        $csp->setDirective($directive, ['something']);
     }
 }


### PR DESCRIPTION
### FIx of the exception notice

Not getting an Error, but a Notice.
This is caused because the $token doesn't contain " " anywhere in the string so it contains only one element in array.list() is used to assign a list of variables in one operation.
list contains 2 elements but as from data returned by explode, there is only one data. So it throws a notice.
A way to overcome that is to use array_pad() method.

The real app provides with the:
```
"Exception: Notice: Undefined offset: 1":
```
Magento Community v2.3.3 -> scenario -> opening a page after:
```
$ composer update
```
and deployment

### Details:

```
Exception: Notice: Undefined offset: 1 in vendor/zendframework/zend-http/src/Header/ContentSecurityPolicy.php on line 115 in vendor/magento/framework/App/ErrorHandler.php:61
Stack trace:
#0 vendor/zendframework/zend-http/src/Header/ContentSecurityPolicy.php(115): Magento\Framework\App\ErrorHandler->handler(8, 'Undefined offse...', 'vendo...', 115, Array)
#1 vendor/zendframework/zend-http/src/Headers.php(471): Zend\Http\Header\ContentSecurityPolicy::fromString('Content-Securit...')
#2 vendor/zendframework/zend-http/src/Headers.php(372): Zend\Http\Headers->lazyLoadHeader(9)
#3 vendor/zendframework/zend-http/src/PhpEnvironment/Response.php(91): Zend\Http\Headers->current()
#4 generated/code/Magento/Framework/App/Response/Http/Interceptor.php(310): Zend\Http\PhpEnvironment\Response->sendHeaders()
#5 vendor/zendframework/zend-http/src/PhpEnvironment/Response.php(126): Magento\Framework\App\Response\Http\Interceptor->sendHeaders()
#6 generated/code/Magento/Framework/App/Response/Http/Interceptor.php(336): Zend\Http\PhpEnvironment\Response->send()
#7 vendor/magento/framework/HTTP/PhpEnvironment/Response.php(39): Magento\Framework\App\Response\Http\Interceptor->send()
#8 vendor/magento/framework/Interception/Interceptor.php(58): Magento\Framework\HTTP\PhpEnvironment\Response->sendResponse()
#9 vendor/magento/framework/Interception/Interceptor.php(138): Magento\Framework\App\Response\Http\Interceptor->___callParent('sendResponse', Array)
#10 vendor/magento/framework/Interception/Interceptor.php(153): Magento\Framework\App\Response\Http\Interceptor->Magento\Framework\Interception\{closure}()
#11 generated/code/Magento/Framework/App/Response/Http/Interceptor.php(117): Magento\Framework\App\Response\Http\Interceptor->___callPlugins('sendResponse', Array, Array)
#12 vendor/magento/framework/App/Http.php(206): Magento\Framework\App\Response\Http\Interceptor->sendResponse()
#13 vendor/magento/framework/App/Http.php(177): Magento\Framework\App\Http->handleDeveloperMode(Object(Magento\Framework\App\Bootstrap), Object(Exception))
#14 vendor/magento/framework/App/Bootstrap.php(267): Magento\Framework\App\Http->catchException(Object(Magento\Framework\App\Bootstrap), Object(Exception))
#15 pub/index.php(40): Magento\Framework\App\Bootstrap->run(Object(Magento\Framework\App\Http))
#16 {main}

```

```
$ cat vendor/zendframework/zend-http/composer.json

{
    "name": "zendframework/zend-http",
    "description": "Provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
    "license": "BSD-3-Clause",
    "keywords": [
        "zf",
        "zend",
        "zendframework",
        "http",
        "HTTP client"
    ],
    "support": {
        "docs": "https://docs.zendframework.com/zend-http/",
        "issues": "https://github.com/zendframework/zend-http/issues",
        "source": "https://github.com/zendframework/zend-http",
        "rss": "https://github.com/zendframework/zend-http/releases.atom",
        "chat": "https://zendframework-slack.herokuapp.com",
        "forum": "https://discourse.zendframework.com/c/questions/components"
    },
    "require": {
        "php": "^5.6 || ^7.0",
        "zendframework/zend-loader": "^2.5.1",
        "zendframework/zend-stdlib": "^3.2.1",
        "zendframework/zend-uri": "^2.5.2",
        "zendframework/zend-validator": "^2.10.1"
    },
    "require-dev": {
        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.3",
        "zendframework/zend-coding-standard": "~1.0.0",
        "zendframework/zend-config": "^3.1 || ^2.6"
    },
    "suggest": {
        "paragonie/certainty": "For automated management of cacert.pem"
    },
    "autoload": {
        "psr-4": {
            "Zend\\Http\\": "src/"
        }
    },
    "autoload-dev": {
        "psr-4": {
            "ZendTest\\Http\\": "test/"
        }
    },
    "config": {
        "sort-packages": true
    },
    "extra": {
        "branch-alias": {
            "dev-master": "2.10.x-dev",
            "dev-develop": "2.11.x-dev"
        }
    },
    "scripts": {
        "check": [
            "@cs-check",
            "@test"
        ],
        "cs-check": "phpcs",
        "cs-fix": "phpcbf",
        "test": "phpunit --colors=always",
        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
    }
}
```


- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
