### PR TITLE
Hotfix: default value for headers is string not null

### DIFF
--- a/src/Header/AcceptRanges.php
+++ b/src/Header/AcceptRanges.php
@@ -27,14 +27,12 @@ class AcceptRanges implements HeaderInterface
             );
         }
 
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($rangeUnit = null)
     {
-        if ($rangeUnit) {
+        if ($rangeUnit !== null) {
             $this->setRangeUnit($rangeUnit);
         }
     }
@@ -58,7 +56,7 @@ class AcceptRanges implements HeaderInterface
 
     public function getRangeUnit()
     {
-        return $this->rangeUnit;
+        return (string) $this->rangeUnit;
     }
 
     public function toString()

--- a/src/Header/Age.php
+++ b/src/Header/Age.php
@@ -37,14 +37,12 @@ class Age implements HeaderInterface
             throw new Exception\InvalidArgumentException('Invalid header line for Age string: "' . $name . '"');
         }
 
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($deltaSeconds = null)
     {
-        if ($deltaSeconds) {
+        if ($deltaSeconds !== null) {
             $this->setDeltaSeconds($deltaSeconds);
         }
     }
@@ -62,11 +60,11 @@ class Age implements HeaderInterface
     /**
      * Get header value (number of seconds)
      *
-     * @return int
+     * @return string
      */
     public function getFieldValue()
     {
-        return $this->getDeltaSeconds();
+        return (string) $this->getDeltaSeconds();
     }
 
     /**

--- a/src/Header/AuthenticationInfo.php
+++ b/src/Header/AuthenticationInfo.php
@@ -31,14 +31,12 @@ class AuthenticationInfo implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -51,7 +49,7 @@ class AuthenticationInfo implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/Authorization.php
+++ b/src/Header/Authorization.php
@@ -31,14 +31,12 @@ class Authorization implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -51,7 +49,7 @@ class Authorization implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/ContentDisposition.php
+++ b/src/Header/ContentDisposition.php
@@ -31,14 +31,12 @@ class ContentDisposition implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -51,7 +49,7 @@ class ContentDisposition implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/ContentEncoding.php
+++ b/src/Header/ContentEncoding.php
@@ -30,14 +30,12 @@ class ContentEncoding implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -50,7 +48,7 @@ class ContentEncoding implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/ContentLanguage.php
+++ b/src/Header/ContentLanguage.php
@@ -31,14 +31,12 @@ class ContentLanguage implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -51,7 +49,7 @@ class ContentLanguage implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/ContentLength.php
+++ b/src/Header/ContentLength.php
@@ -31,9 +31,7 @@ class ContentLength implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
@@ -51,7 +49,7 @@ class ContentLength implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/ContentMD5.php
+++ b/src/Header/ContentMD5.php
@@ -28,14 +28,12 @@ class ContentMD5 implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class ContentMD5 implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/ContentRange.php
+++ b/src/Header/ContentRange.php
@@ -31,14 +31,12 @@ class ContentRange implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -51,7 +49,7 @@ class ContentRange implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/ContentTransferEncoding.php
+++ b/src/Header/ContentTransferEncoding.php
@@ -31,14 +31,12 @@ class ContentTransferEncoding implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static(strtolower($value));
-
-        return $header;
+        return new static(strtolower($value));
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -51,7 +49,7 @@ class ContentTransferEncoding implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/ContentType.php
+++ b/src/Header/ContentType.php
@@ -69,7 +69,7 @@ class ContentType implements HeaderInterface
 
     public function __construct($value = null, $mediaType = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -146,7 +146,7 @@ class ContentType implements HeaderInterface
     public function getFieldValue()
     {
         if (null !== $this->value) {
-            return $this->value;
+            return (string) $this->value;
         }
         return $this->assembleValue();
     }
@@ -172,7 +172,7 @@ class ContentType implements HeaderInterface
      */
     public function getMediaType()
     {
-        return $this->mediaType;
+        return (string) $this->mediaType;
     }
 
     /**

--- a/src/Header/Etag.php
+++ b/src/Header/Etag.php
@@ -28,14 +28,12 @@ class Etag implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class Etag implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/Expect.php
+++ b/src/Header/Expect.php
@@ -28,14 +28,12 @@ class Expect implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class Expect implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/From.php
+++ b/src/Header/From.php
@@ -28,14 +28,12 @@ class From implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class From implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/Host.php
+++ b/src/Header/Host.php
@@ -28,14 +28,12 @@ class Host implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class Host implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/IfMatch.php
+++ b/src/Header/IfMatch.php
@@ -28,14 +28,12 @@ class IfMatch implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class IfMatch implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/IfNoneMatch.php
+++ b/src/Header/IfNoneMatch.php
@@ -31,14 +31,12 @@ class IfNoneMatch implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -51,7 +49,7 @@ class IfNoneMatch implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/IfRange.php
+++ b/src/Header/IfRange.php
@@ -28,14 +28,12 @@ class IfRange implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class IfRange implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/KeepAlive.php
+++ b/src/Header/KeepAlive.php
@@ -28,14 +28,12 @@ class KeepAlive implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class KeepAlive implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/MaxForwards.php
+++ b/src/Header/MaxForwards.php
@@ -31,14 +31,12 @@ class MaxForwards implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -51,7 +49,7 @@ class MaxForwards implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/Origin.php
+++ b/src/Header/Origin.php
@@ -42,7 +42,7 @@ class Origin implements HeaderInterface
      */
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -55,7 +55,7 @@ class Origin implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/Pragma.php
+++ b/src/Header/Pragma.php
@@ -28,14 +28,12 @@ class Pragma implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class Pragma implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/ProxyAuthenticate.php
+++ b/src/Header/ProxyAuthenticate.php
@@ -31,14 +31,12 @@ class ProxyAuthenticate implements MultipleHeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -51,7 +49,7 @@ class ProxyAuthenticate implements MultipleHeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/ProxyAuthorization.php
+++ b/src/Header/ProxyAuthorization.php
@@ -31,14 +31,12 @@ class ProxyAuthorization implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -51,7 +49,7 @@ class ProxyAuthorization implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/Range.php
+++ b/src/Header/Range.php
@@ -28,14 +28,12 @@ class Range implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class Range implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/Refresh.php
+++ b/src/Header/Refresh.php
@@ -28,14 +28,12 @@ class Refresh implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class Refresh implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/Server.php
+++ b/src/Header/Server.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-http for the canonical source repository
- * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-http/blob/master/LICENSE.md New BSD License
  */
 
@@ -28,14 +28,12 @@ class Server implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class Server implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/TE.php
+++ b/src/Header/TE.php
@@ -28,14 +28,12 @@ class TE implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class TE implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/Trailer.php
+++ b/src/Header/Trailer.php
@@ -28,14 +28,12 @@ class Trailer implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class Trailer implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/TransferEncoding.php
+++ b/src/Header/TransferEncoding.php
@@ -30,14 +30,12 @@ class TransferEncoding implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -50,7 +48,7 @@ class TransferEncoding implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/Upgrade.php
+++ b/src/Header/Upgrade.php
@@ -28,14 +28,12 @@ class Upgrade implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class Upgrade implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/UserAgent.php
+++ b/src/Header/UserAgent.php
@@ -28,14 +28,12 @@ class UserAgent implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class UserAgent implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/Vary.php
+++ b/src/Header/Vary.php
@@ -28,14 +28,12 @@ class Vary implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class Vary implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/Via.php
+++ b/src/Header/Via.php
@@ -28,14 +28,12 @@ class Via implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class Via implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/WWWAuthenticate.php
+++ b/src/Header/WWWAuthenticate.php
@@ -31,14 +31,12 @@ class WWWAuthenticate implements MultipleHeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -51,7 +49,7 @@ class WWWAuthenticate implements MultipleHeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/src/Header/Warning.php
+++ b/src/Header/Warning.php
@@ -28,14 +28,12 @@ class Warning implements HeaderInterface
         }
 
         // @todo implementation details
-        $header = new static($value);
-
-        return $header;
+        return new static($value);
     }
 
     public function __construct($value = null)
     {
-        if ($value) {
+        if ($value !== null) {
             HeaderValue::assertValid($value);
             $this->value = $value;
         }
@@ -48,7 +46,7 @@ class Warning implements HeaderInterface
 
     public function getFieldValue()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     public function toString()

--- a/test/HeaderTest.php
+++ b/test/HeaderTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-http for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-http/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Http;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Http\Exception\InvalidArgumentException;
+use Zend\Http\Header;
+
+class HeaderTest extends TestCase
+{
+    public function header()
+    {
+        // @codingStandardsIgnoreStart
+        yield Header\AuthenticationInfo::class      => [Header\AuthenticationInfo::class, 'Authentication-Info'];
+        yield Header\Authorization::class           => [Header\Authorization::class, 'Authorization'];
+        yield Header\ContentDisposition::class      => [Header\ContentDisposition::class, 'Content-Disposition'];
+        yield Header\ContentEncoding::class         => [Header\ContentEncoding::class, 'Content-Encoding'];
+        yield Header\ContentLanguage::class         => [Header\ContentLanguage::class, 'Content-Language'];
+        yield Header\ContentLength::class           => [Header\ContentLength::class, 'Content-Length'];
+        yield Header\ContentMD5::class              => [Header\ContentMD5::class, 'Content-MD5'];
+        yield Header\ContentRange::class            => [Header\ContentRange::class, 'Content-Range'];
+        yield Header\ContentTransferEncoding::class => [Header\ContentTransferEncoding::class, 'Content-Transfer-Encoding'];
+        yield Header\ContentType::class             => [Header\ContentType::class, 'Content-Type'];
+        yield Header\Etag::class                    => [Header\Etag::class, 'Etag'];
+        yield Header\Expect::class                  => [Header\Expect::class, 'Expect'];
+        yield Header\From::class                    => [Header\From::class, 'From'];
+        yield Header\Host::class                    => [Header\Host::class, 'Host'];
+        yield Header\IfMatch::class                 => [Header\IfMatch::class, 'If-Match'];
+        yield Header\IfNoneMatch::class             => [Header\IfNoneMatch::class, 'If-None-Match'];
+        yield Header\IfRange::class                 => [Header\IfRange::class, 'If-Range'];
+        yield Header\KeepAlive::class               => [Header\KeepAlive::class, 'Keep-Alive'];
+        yield Header\MaxForwards::class             => [Header\MaxForwards::class, 'Max-Forwards'];
+        yield Header\Origin::class                  => [Header\Origin::class, 'Origin'];
+        yield Header\Pragma::class                  => [Header\Pragma::class, 'Pragma'];
+        yield Header\ProxyAuthenticate::class       => [Header\ProxyAuthenticate::class, 'Proxy-Authenticate'];
+        yield Header\ProxyAuthorization::class      => [Header\ProxyAuthorization::class, 'Proxy-Authorization'];
+        yield Header\Range::class                   => [Header\Range::class, 'Range'];
+        yield Header\Refresh::class                 => [Header\Refresh::class, 'Refresh'];
+        yield Header\Server::class                  => [Header\Server::class, 'Server'];
+        yield Header\TE::class                      => [Header\TE::class, 'TE'];
+        yield Header\Trailer::class                 => [Header\Trailer::class, 'Trailer'];
+        yield Header\TransferEncoding::class        => [Header\TransferEncoding::class, 'Transfer-Encoding'];
+        yield Header\Upgrade::class                 => [Header\Upgrade::class, 'Upgrade'];
+        yield Header\UserAgent::class               => [Header\UserAgent::class, 'User-Agent'];
+        yield Header\Vary::class                    => [Header\Vary::class, 'Vary'];
+        yield Header\Via::class                     => [Header\Via::class, 'Via'];
+        yield Header\Warning::class                 => [Header\Warning::class, 'Warning'];
+        yield Header\WWWAuthenticate::class         => [Header\WWWAuthenticate::class, 'WWW-Authenticate'];
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * @dataProvider header
+     *
+     * @param string $class
+     * @param string $name
+     */
+    public function testThrowsExceptionIfInvalidHeaderLine($class, $name)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid header line for ' . $name . ' string');
+        $class::fromString($name . '-Foo: bar');
+    }
+
+    /**
+     * @dataProvider header
+     *
+     * @param string $class
+     * @param string $name
+     */
+    public function testCaseInsensitiveHeaderName($class, $name)
+    {
+        $header1 = $class::fromString(strtoupper($name) . ': foo');
+        self::assertSame('foo', $header1->getFieldValue());
+
+        $header2 = $class::fromString(strtolower($name) . ': bar');
+        self::assertSame('bar', $header2->getFieldValue());
+    }
+
+    /**
+     * @dataProvider header
+     *
+     * @param string $class
+     * @param string $name
+     */
+    public function testDefaultValues($class, $name)
+    {
+        $header = new $class();
+
+        self::assertSame('', $header->getFieldValue());
+        self::assertSame($name, $header->getFieldName());
+        self::assertSame($name . ': ', $header->toString());
+    }
+
+    /**
+     * @dataProvider header
+     *
+     * @param string $class
+     * @param string $name
+     */
+    public function testSetValueViaConstructor($class, $name)
+    {
+        $header = new $class('foo-bar');
+
+        self::assertSame('foo-bar', $header->getFieldValue());
+        self::assertSame($name . ': foo-bar', $header->toString());
+    }
+
+    /**
+     * @dataProvider header
+     *
+     * @param string $class
+     * @param string $name
+     *
+     * Note: in theory this is invalid, as we would expect value to be string|null.
+     * Null is default value but it is converted to string.
+     */
+    public function testSetIntValueViaConstructor($class, $name)
+    {
+        $header = new $class(100);
+
+        self::assertSame('100', $header->getFieldValue());
+        self::assertSame($name . ': 100', $header->toString());
+    }
+
+    /**
+     * @dataProvider header
+     *
+     * @param string $class
+     * @param string $name
+     */
+    public function testFromStringWithNumber($class, $name)
+    {
+        $header = $class::fromString($name . ': 100');
+
+        self::assertSame('100', $header->getFieldValue());
+        self::assertSame($name . ': 100', $header->toString());
+    }
+}

--- a/test/HeaderTest.php
+++ b/test/HeaderTest.php
@@ -134,6 +134,20 @@ class HeaderTest extends TestCase
      * @param string $class
      * @param string $name
      */
+    public function testSetZeroStringValueViaConstructor($class, $name)
+    {
+        $header = new $class('0');
+
+        self::assertSame('0', $header->getFieldValue());
+        self::assertSame($name . ': 0', $header->toString());
+    }
+
+    /**
+     * @dataProvider header
+     *
+     * @param string $class
+     * @param string $name
+     */
     public function testFromStringWithNumber($class, $name)
     {
         $header = $class::fromString($name . ': 100');

--- a/test/HeaderTest.php
+++ b/test/HeaderTest.php
@@ -16,6 +16,7 @@ class HeaderTest extends TestCase
     public function header()
     {
         // @codingStandardsIgnoreStart
+        yield Header\AcceptRanges::class            => [Header\AcceptRanges::class, 'Accept-Ranges'];
         yield Header\AuthenticationInfo::class      => [Header\AuthenticationInfo::class, 'Authentication-Info'];
         yield Header\Authorization::class           => [Header\Authorization::class, 'Authorization'];
         yield Header\ContentDisposition::class      => [Header\ContentDisposition::class, 'Content-Disposition'];


### PR DESCRIPTION
As per specification default value for headers should be string, not null.
In many cases it was invalid as we return null instead.

Also, when creating new instance with empty string, again - null was
returned instead.

Fixes #202