### PR TITLE
fixes case sensitivity for SameSite directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- fixes case sensitivity for SameSite directive.
 
 ## 2.11.1 - 2019-12-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- fixes case sensitivity for SameSite directive.
+- [#207](https://github.com/zendframework/zend-http/pull/207) fixes case sensitivity for SameSite directive.
 
 ## 2.11.1 - 2019-12-04
 

--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -618,18 +618,17 @@ class SetCookie implements MultipleHeaderInterface
      */
     public function setSameSite($sameSite)
     {
-        if ($sameSite !== null) {
-            if (array_key_exists(strtolower($sameSite), self::SAME_SITE_ALLOWED_VALUES)) {
-                $this->sameSite = self::SAME_SITE_ALLOWED_VALUES[strtolower($sameSite)];
-            } else {
-                throw new Exception\InvalidArgumentException(sprintf(
-                    'Invalid value provided for SameSite directive: "%s"; expected one of: Strict, Lax or None',
-                    is_scalar($sameSite) ? $sameSite : gettype($sameSite)
-                ));
-            }
-        } else {
-            $this->sameSite = $sameSite;
+        if ($sameSite === null) {
+            $this->sameSite = null;
+            return $this;
         }
+        if (! array_key_exists(strtolower($sameSite), self::SAME_SITE_ALLOWED_VALUES)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Invalid value provided for SameSite directive: "%s"; expected one of: Strict, Lax or None',
+                is_scalar($sameSite) ? $sameSite : gettype($sameSite)
+            ));
+        }
+        $this->sameSite = self::SAME_SITE_ALLOWED_VALUES[strtolower($sameSite)];
         return $this;
     }
 

--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -39,9 +39,9 @@ class SetCookie implements MultipleHeaderInterface
      * @internal
      */
     const SAME_SITE_ALLOWED_VALUES = [
-        self::SAME_SITE_STRICT,
-        self::SAME_SITE_LAX,
-        self::SAME_SITE_NONE,
+        'strict',
+        'lax',
+        'none',
     ];
 
     /**
@@ -337,8 +337,7 @@ class SetCookie implements MultipleHeaderInterface
         }
 
         $sameSite = $this->getSameSite();
-        if ($sameSite !== null
-            && in_array(strtolower($sameSite), array_map('strtolower', self::SAME_SITE_ALLOWED_VALUES), true)) {
+        if ($sameSite !== null && in_array(strtolower($sameSite), self::SAME_SITE_ALLOWED_VALUES, true)) {
             $fieldValue .= '; SameSite=' . $sameSite;
         }
 
@@ -619,8 +618,7 @@ class SetCookie implements MultipleHeaderInterface
      */
     public function setSameSite($sameSite)
     {
-        if ($sameSite !== null
-            && ! in_array(strtolower($sameSite), array_map('strtolower', self::SAME_SITE_ALLOWED_VALUES), true)) {
+        if ($sameSite !== null && ! in_array(strtolower($sameSite), self::SAME_SITE_ALLOWED_VALUES, true)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Invalid value provided for SameSite directive: "%s"; expected one of: Strict, Lax or None',
                 is_scalar($sameSite) ? $sameSite : gettype($sameSite)

--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -251,15 +251,15 @@ class SetCookie implements MultipleHeaderInterface
         $this->type = 'Cookie';
 
         $this->setName($name)
-             ->setValue($value)
-             ->setVersion($version)
-             ->setMaxAge($maxAge)
-             ->setDomain($domain)
-             ->setExpires($expires)
-             ->setPath($path)
-             ->setSecure($secure)
-             ->setHttpOnly($httponly)
-             ->setSameSite($sameSite);
+            ->setValue($value)
+            ->setVersion($version)
+            ->setMaxAge($maxAge)
+            ->setDomain($domain)
+            ->setExpires($expires)
+            ->setPath($path)
+            ->setSecure($secure)
+            ->setHttpOnly($httponly)
+            ->setSameSite($sameSite);
     }
 
     /**
@@ -337,7 +337,8 @@ class SetCookie implements MultipleHeaderInterface
         }
 
         $sameSite = $this->getSameSite();
-        if ($sameSite !== null && in_array($sameSite, self::SAME_SITE_ALLOWED_VALUES, true)) {
+        if ($sameSite !== null
+            && in_array(strtolower($sameSite), array_map('strtolower', self::SAME_SITE_ALLOWED_VALUES), true)) {
             $fieldValue .= '; SameSite=' . $sameSite;
         }
 
@@ -618,7 +619,8 @@ class SetCookie implements MultipleHeaderInterface
      */
     public function setSameSite($sameSite)
     {
-        if ($sameSite !== null && ! in_array($sameSite, self::SAME_SITE_ALLOWED_VALUES, true)) {
+        if ($sameSite !== null
+            && ! in_array(strtolower($sameSite), array_map('strtolower', self::SAME_SITE_ALLOWED_VALUES), true)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Invalid value provided for SameSite directive: "%s"; expected one of: Strict, Lax or None',
                 is_scalar($sameSite) ? $sameSite : gettype($sameSite)

--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -10,6 +10,11 @@ namespace Zend\Http\Header;
 use DateTime;
 use Zend\Uri\UriFactory;
 
+use function array_key_exists;
+use function gettype;
+use function is_scalar;
+use function strtolower;
+
 /**
  * @throws Exception\InvalidArgumentException
  * @see http://www.ietf.org/rfc/rfc2109.txt

--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -39,9 +39,9 @@ class SetCookie implements MultipleHeaderInterface
      * @internal
      */
     const SAME_SITE_ALLOWED_VALUES = [
-        'strict',
-        'lax',
-        'none',
+        'strict' => self::SAME_SITE_STRICT,
+        'lax' => self::SAME_SITE_LAX,
+        'none' => self::SAME_SITE_NONE
     ];
 
     /**
@@ -337,7 +337,7 @@ class SetCookie implements MultipleHeaderInterface
         }
 
         $sameSite = $this->getSameSite();
-        if ($sameSite !== null && in_array(strtolower($sameSite), self::SAME_SITE_ALLOWED_VALUES, true)) {
+        if ($sameSite !== null && array_key_exists(strtolower($sameSite), self::SAME_SITE_ALLOWED_VALUES)) {
             $fieldValue .= '; SameSite=' . $sameSite;
         }
 
@@ -618,13 +618,18 @@ class SetCookie implements MultipleHeaderInterface
      */
     public function setSameSite($sameSite)
     {
-        if ($sameSite !== null && ! in_array(strtolower($sameSite), self::SAME_SITE_ALLOWED_VALUES, true)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'Invalid value provided for SameSite directive: "%s"; expected one of: Strict, Lax or None',
-                is_scalar($sameSite) ? $sameSite : gettype($sameSite)
-            ));
+        if ($sameSite !== null) {
+            if (array_key_exists(strtolower($sameSite), self::SAME_SITE_ALLOWED_VALUES)) {
+                $this->sameSite = self::SAME_SITE_ALLOWED_VALUES[strtolower($sameSite)];
+            } else {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'Invalid value provided for SameSite directive: "%s"; expected one of: Strict, Lax or None',
+                    is_scalar($sameSite) ? $sameSite : gettype($sameSite)
+                ));
+            }
+        } else {
+            $this->sameSite = $sameSite;
         }
-        $this->sameSite = $sameSite;
         return $this;
     }
 

--- a/src/Header/SetCookie.php
+++ b/src/Header/SetCookie.php
@@ -251,15 +251,15 @@ class SetCookie implements MultipleHeaderInterface
         $this->type = 'Cookie';
 
         $this->setName($name)
-            ->setValue($value)
-            ->setVersion($version)
-            ->setMaxAge($maxAge)
-            ->setDomain($domain)
-            ->setExpires($expires)
-            ->setPath($path)
-            ->setSecure($secure)
-            ->setHttpOnly($httponly)
-            ->setSameSite($sameSite);
+             ->setValue($value)
+             ->setVersion($version)
+             ->setMaxAge($maxAge)
+             ->setDomain($domain)
+             ->setExpires($expires)
+             ->setPath($path)
+             ->setSecure($secure)
+             ->setHttpOnly($httponly)
+             ->setSameSite($sameSite);
     }
 
     /**

--- a/test/Header/SetCookieTest.php
+++ b/test/Header/SetCookieTest.php
@@ -14,6 +14,9 @@ use Zend\Http\Header\HeaderInterface;
 use Zend\Http\Header\MultipleHeaderInterface;
 use Zend\Http\Header\SetCookie;
 
+use function strtolower;
+use function strtoupper;
+
 class SetCookieTest extends TestCase
 {
     /**
@@ -147,33 +150,11 @@ class SetCookieTest extends TestCase
         );
         $this->assertEquals(SetCookie::SAME_SITE_STRICT, $setCookieHeader->getSameSite());
 
-        $setCookieHeader = new SetCookie(
-            'myname',
-            'myvalue',
-            'Wed, 13-Jan-2021 22:23:01 GMT',
-            '/accounts',
-            'docs.foo.com',
-            true,
-            true,
-            99,
-            9,
-            strtolower(SetCookie::SAME_SITE_STRICT)
-        );
-        $this->assertEquals(SetCookie::SAME_SITE_STRICT, $setCookieHeader->getSameSite());
+        $setCookieHeader->setSameSite(strtolower(SetCookie::SAME_SITE_LAX));
+        $this->assertEquals(SetCookie::SAME_SITE_LAX, $setCookieHeader->getSameSite());
 
-        $setCookieHeader = new SetCookie(
-            'myname',
-            'myvalue',
-            'Wed, 13-Jan-2021 22:23:01 GMT',
-            '/accounts',
-            'docs.foo.com',
-            true,
-            true,
-            99,
-            9,
-            strtoupper(SetCookie::SAME_SITE_STRICT)
-        );
-        $this->assertEquals(SetCookie::SAME_SITE_STRICT, $setCookieHeader->getSameSite());
+        $setCookieHeader->setSameSite(strtoupper(SetCookie::SAME_SITE_NONE));
+        $this->assertEquals(SetCookie::SAME_SITE_NONE, $setCookieHeader->getSameSite());
     }
 
     public function testSetCookieFromStringWithQuotedValue()

--- a/test/Header/SetCookieTest.php
+++ b/test/Header/SetCookieTest.php
@@ -187,11 +187,6 @@ class SetCookieTest extends TestCase
         $this->assertTrue($setCookieHeader->isSecure());
         $this->assertTrue($setCookieHeader->isHttponly());
         $this->assertEquals(setCookie::SAME_SITE_STRICT, $setCookieHeader->getSameSite());
-        $this->assertEquals(
-            'myname=myvalue; Expires=Wed, 13-Jan-2021 22:23:01 GMT; Domain=docs.foo.com; '
-            . 'Path=/accounts; Secure; HttpOnly; SameSite=Strict',
-            $setCookieHeader->getFieldValue()
-        );
 
         $setCookieHeader = SetCookie::fromString(
             'set-cookie: myname=myvalue; Domain=docs.foo.com; Path=/accounts;'
@@ -206,9 +201,22 @@ class SetCookieTest extends TestCase
         $this->assertTrue($setCookieHeader->isSecure());
         $this->assertTrue($setCookieHeader->isHttponly());
         $this->assertEquals(strtolower(setCookie::SAME_SITE_STRICT), $setCookieHeader->getSameSite());
+    }
+
+    public function testFieldValueWithSameSiteCaseInsensitive() {
+        $setCookieHeader = SetCookie::fromString(
+            'set-cookie: myname=myvalue; SameSite=Strict'
+        );
         $this->assertEquals(
-            'myname=myvalue; Expires=Wed, 13-Jan-2021 22:23:01 GMT; Domain=docs.foo.com; '
-            . 'Path=/accounts; Secure; HttpOnly; SameSite=strict',
+            'myname=myvalue; SameSite=Strict',
+            $setCookieHeader->getFieldValue()
+        );
+
+        $setCookieHeader = SetCookie::fromString(
+            'set-cookie: myname=myvalue; SameSite=strict'
+        );
+        $this->assertEquals(
+            'myname=myvalue; SameSite=strict',
             $setCookieHeader->getFieldValue()
         );
     }

--- a/test/Header/SetCookieTest.php
+++ b/test/Header/SetCookieTest.php
@@ -203,7 +203,8 @@ class SetCookieTest extends TestCase
         $this->assertEquals(strtolower(setCookie::SAME_SITE_STRICT), $setCookieHeader->getSameSite());
     }
 
-    public function testFieldValueWithSameSiteCaseInsensitive() {
+    public function testFieldValueWithSameSiteCaseInsensitive()
+    {
         $setCookieHeader = SetCookie::fromString(
             'set-cookie: myname=myvalue; SameSite=Strict'
         );

--- a/test/Header/SetCookieTest.php
+++ b/test/Header/SetCookieTest.php
@@ -69,6 +69,32 @@ class SetCookieTest extends TestCase
         $this->assertEquals('Strict', $setCookieHeader->getSameSite());
     }
 
+    public function testSetCookieConstructorWithSameSiteCaseInsensitive()
+    {
+        $setCookieHeader = new SetCookie(
+            'myname',
+            'myvalue',
+            'Wed, 13-Jan-2021 22:23:01 GMT',
+            '/accounts',
+            'docs.foo.com',
+            true,
+            true,
+            99,
+            9,
+            strtolower(SetCookie::SAME_SITE_STRICT)
+        );
+        $this->assertEquals('myname', $setCookieHeader->getName());
+        $this->assertEquals('myvalue', $setCookieHeader->getValue());
+        $this->assertEquals('Wed, 13-Jan-2021 22:23:01 GMT', $setCookieHeader->getExpires());
+        $this->assertEquals('/accounts', $setCookieHeader->getPath());
+        $this->assertEquals('docs.foo.com', $setCookieHeader->getDomain());
+        $this->assertTrue($setCookieHeader->isSecure());
+        $this->assertTrue($setCookieHeader->isHttpOnly());
+        $this->assertEquals(99, $setCookieHeader->getMaxAge());
+        $this->assertEquals(9, $setCookieHeader->getVersion());
+        $this->assertEquals(strtolower(SetCookie::SAME_SITE_STRICT), $setCookieHeader->getSameSite());
+    }
+
     public function testSetCookieWithInvalidSameSiteValueThrowException()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -161,6 +187,30 @@ class SetCookieTest extends TestCase
         $this->assertTrue($setCookieHeader->isSecure());
         $this->assertTrue($setCookieHeader->isHttponly());
         $this->assertEquals(setCookie::SAME_SITE_STRICT, $setCookieHeader->getSameSite());
+        $this->assertEquals(
+            'myname=myvalue; Expires=Wed, 13-Jan-2021 22:23:01 GMT; Domain=docs.foo.com; '
+            . 'Path=/accounts; Secure; HttpOnly; SameSite=Strict',
+            $setCookieHeader->getFieldValue()
+        );
+
+        $setCookieHeader = SetCookie::fromString(
+            'set-cookie: myname=myvalue; Domain=docs.foo.com; Path=/accounts;'
+            . 'Expires=Wed, 13-Jan-2021 22:23:01 GMT; Secure; HttpOnly; SameSite=strict'
+        );
+        $this->assertInstanceOf(MultipleHeaderInterface::class, $setCookieHeader);
+        $this->assertEquals('myname', $setCookieHeader->getName());
+        $this->assertEquals('myvalue', $setCookieHeader->getValue());
+        $this->assertEquals('docs.foo.com', $setCookieHeader->getDomain());
+        $this->assertEquals('/accounts', $setCookieHeader->getPath());
+        $this->assertEquals('Wed, 13-Jan-2021 22:23:01 GMT', $setCookieHeader->getExpires());
+        $this->assertTrue($setCookieHeader->isSecure());
+        $this->assertTrue($setCookieHeader->isHttponly());
+        $this->assertEquals(strtolower(setCookie::SAME_SITE_STRICT), $setCookieHeader->getSameSite());
+        $this->assertEquals(
+            'myname=myvalue; Expires=Wed, 13-Jan-2021 22:23:01 GMT; Domain=docs.foo.com; '
+            . 'Path=/accounts; Secure; HttpOnly; SameSite=strict',
+            $setCookieHeader->getFieldValue()
+        );
     }
 
     public function testSetCookieFromStringCanCreateMultipleHeaders()

--- a/test/Header/SetCookieTest.php
+++ b/test/Header/SetCookieTest.php
@@ -92,7 +92,7 @@ class SetCookieTest extends TestCase
         $this->assertTrue($setCookieHeader->isHttpOnly());
         $this->assertEquals(99, $setCookieHeader->getMaxAge());
         $this->assertEquals(9, $setCookieHeader->getVersion());
-        $this->assertEquals(strtolower(SetCookie::SAME_SITE_STRICT), $setCookieHeader->getSameSite());
+        $this->assertEquals(SetCookie::SAME_SITE_STRICT, $setCookieHeader->getSameSite());
     }
 
     public function testSetCookieWithInvalidSameSiteValueThrowException()
@@ -200,7 +200,7 @@ class SetCookieTest extends TestCase
         $this->assertEquals('Wed, 13-Jan-2021 22:23:01 GMT', $setCookieHeader->getExpires());
         $this->assertTrue($setCookieHeader->isSecure());
         $this->assertTrue($setCookieHeader->isHttponly());
-        $this->assertEquals(strtolower(setCookie::SAME_SITE_STRICT), $setCookieHeader->getSameSite());
+        $this->assertEquals(setCookie::SAME_SITE_STRICT, $setCookieHeader->getSameSite());
     }
 
     public function testFieldValueWithSameSiteCaseInsensitive()
@@ -217,7 +217,7 @@ class SetCookieTest extends TestCase
             'set-cookie: myname=myvalue; SameSite=strict'
         );
         $this->assertEquals(
-            'myname=myvalue; SameSite=strict',
+            'myname=myvalue; SameSite=Strict',
             $setCookieHeader->getFieldValue()
         );
     }

--- a/test/Header/SetCookieTest.php
+++ b/test/Header/SetCookieTest.php
@@ -131,6 +131,51 @@ class SetCookieTest extends TestCase
         $setCookieHeader->setSameSite('InvalidValue');
     }
 
+    public function testSameSiteGetterReturnsCanonicalValue()
+    {
+        $setCookieHeader = new SetCookie(
+            'myname',
+            'myvalue',
+            'Wed, 13-Jan-2021 22:23:01 GMT',
+            '/accounts',
+            'docs.foo.com',
+            true,
+            true,
+            99,
+            9,
+            SetCookie::SAME_SITE_STRICT
+        );
+        $this->assertEquals(SetCookie::SAME_SITE_STRICT, $setCookieHeader->getSameSite());
+
+        $setCookieHeader = new SetCookie(
+            'myname',
+            'myvalue',
+            'Wed, 13-Jan-2021 22:23:01 GMT',
+            '/accounts',
+            'docs.foo.com',
+            true,
+            true,
+            99,
+            9,
+            strtolower(SetCookie::SAME_SITE_STRICT)
+        );
+        $this->assertEquals(SetCookie::SAME_SITE_STRICT, $setCookieHeader->getSameSite());
+
+        $setCookieHeader = new SetCookie(
+            'myname',
+            'myvalue',
+            'Wed, 13-Jan-2021 22:23:01 GMT',
+            '/accounts',
+            'docs.foo.com',
+            true,
+            true,
+            99,
+            9,
+            strtoupper(SetCookie::SAME_SITE_STRICT)
+        );
+        $this->assertEquals(SetCookie::SAME_SITE_STRICT, $setCookieHeader->getSameSite());
+    }
+
     public function testSetCookieFromStringWithQuotedValue()
     {
         $setCookieHeader = SetCookie::fromString('Set-Cookie: myname="quotedValue"');


### PR DESCRIPTION
This fix handles case sensitivity for SameSite directive in cookie headers.

Prior to this fix the SameSite values were case sensitive compared with their capitalized names (`Lax`, `Strict`, `None`). This fix allows for case insensitive comparison, allowing values like `lax` and `LAX`. 

See https://github.com/zendframework/zend-http/issues/206 for more information 
